### PR TITLE
Refactor artist selection

### DIFF
--- a/components/ArtistAutocomplete.tsx
+++ b/components/ArtistAutocomplete.tsx
@@ -7,8 +7,7 @@ import {
   FlatList,
   StyleSheet,
 } from 'react-native';
-import { searchArtistsByName, ArtistData } from '@/services/artistService';
-import { supabase } from '@/lib/supabase'; // make sure this path is correct
+import { searchArtistsByName, findOrCreateArtistByName, ArtistData } from '@/services/artistService';
 import { User, X } from 'lucide-react-native';
 
 interface ArtistAutocompleteProps {
@@ -84,24 +83,13 @@ export function ArtistAutocomplete({
   };
 
   const handleCreateNewArtist = async () => {
-    const name = query.trim();
-    if (!name) return;
+    const artist = await findOrCreateArtistByName(query);
+    if (!artist) return;
 
-    const { data, error } = await supabase
-      .from('artists')
-      .insert([{ name }])
-      .select()
-      .single();
-
-    if (error) {
-      console.error('Error creating artist:', error);
-      return;
-    }
-
-    setQuery(data.name);
+    setQuery(artist.name);
     setSuggestions([]);
     setShowSuggestions(false);
-    onArtistSelect(data);
+    onArtistSelect(artist);
   };
 
   const renderSuggestionItem = ({ item }: { item: ArtistData }) => (

--- a/services/artistService.ts
+++ b/services/artistService.ts
@@ -1,4 +1,4 @@
-import { supabase } from '@/lib/supabaseClient';
+import { supabase } from '@/providers/AuthProvider';
 
 export interface ArtistData {
   id: string;
@@ -18,4 +18,38 @@ export async function searchArtistsByName(query: string, limit = 8): Promise<Art
   }
 
   return data || [];
+}
+
+export async function findOrCreateArtistByName(name: string): Promise<ArtistData | null> {
+  const trimmed = name.trim();
+  if (!trimmed) return null;
+
+  const { data: existing, error: searchError } = await supabase
+    .from('artists')
+    .select('id, name')
+    .ilike('name', trimmed)
+    .limit(1)
+    .maybeSingle();
+
+  if (searchError && searchError.code !== 'PGRST116') {
+    console.error('Supabase error searching artist:', searchError.message);
+    return null;
+  }
+
+  if (existing) {
+    return existing as ArtistData;
+  }
+
+  const { data: created, error: insertError } = await supabase
+    .from('artists')
+    .insert({ name: trimmed })
+    .select('id, name')
+    .single();
+
+  if (insertError) {
+    console.error('Supabase error creating artist:', insertError.message);
+    return null;
+  }
+
+  return created as ArtistData;
 }

--- a/services/uploadService.ts
+++ b/services/uploadService.ts
@@ -13,8 +13,8 @@ export interface SingleUploadData {
   releaseDate?: string;
   price?: string;
   artistId: string;
-  mainArtist: string;
-  featuredArtists: string[];
+  mainArtistId: string;
+  featuredArtistIds: string[];
 }
 
 export interface AlbumUploadData {
@@ -25,8 +25,8 @@ export interface AlbumUploadData {
   genres: string[];
   explicit: boolean;
   artistId: string;
-  mainArtist: string;
-  featuredArtists: string[];
+  mainArtistId: string;
+  featuredArtistIds: string[];
   tracks: Array<{
     title: string;
     audioFile: any;
@@ -34,7 +34,7 @@ export interface AlbumUploadData {
     explicit: boolean;
     trackNumber: number;
     duration?: number;
-    featuringArtists: string[];
+    featuredArtistIds: string[];
   }>;
 }
 
@@ -71,7 +71,7 @@ class UploadService {
       // Step 3: Create track record in database
       const trackData = {
         title: singleData.title,
-        artist_id: singleData.mainArtist,
+        artist_id: singleData.mainArtistId,
         audio_url: audioUpload.url,
         cover_url: coverUpload?.url || null,
         lyrics: singleData.lyrics || '',
@@ -84,7 +84,7 @@ class UploadService {
         is_published: false, // Admin approval required
         track_number: 1,
         created_by: session.user.id,
-        featured_artist_ids: singleData.featuredArtists,
+        featured_artist_ids: singleData.featuredArtistIds,
       };
 
       const { data: track, error: trackError } = await supabase
@@ -136,7 +136,7 @@ class UploadService {
       // Step 2: Create album record
       const albumRecord = {
         title: albumData.title,
-        artist_id: albumData.mainArtist,
+        artist_id: albumData.mainArtistId,
         cover_url: albumCoverUpload?.url || null,
         description: albumData.description || '',
         release_date: albumData.releaseDate || new Date().toISOString().split('T')[0],
@@ -145,7 +145,7 @@ class UploadService {
         track_count: albumData.tracks.length,
         is_published: false, // Admin approval required
         created_by: session.user.id,
-        featured_artist_ids: albumData.featuredArtists,
+        featured_artist_ids: albumData.featuredArtistIds,
       };
 
       const { data: album, error: albumError } = await supabase
@@ -178,7 +178,7 @@ class UploadService {
           // Create track record
           const trackData = {
             title: track.title,
-            artist_id: albumData.mainArtist,
+            artist_id: albumData.mainArtistId,
             album_id: album.id,
             audio_url: audioUpload.url,
             cover_url: album.cover_url, // Use album cover for tracks
@@ -189,7 +189,7 @@ class UploadService {
             track_number: track.trackNumber,
             is_published: false, // Admin approval required
             created_by: session.user.id,
-            featured_artist_ids: track.featuringArtists,
+            featured_artist_ids: track.featuredArtistIds,
           };
 
           const { data: trackRecord, error: trackError } = await supabase

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,8 +2,9 @@
   "extends": "expo/tsconfig.base",
   "compilerOptions": {
     "strict": true,
+    "baseUrl": "./",
     "paths": {
-      "@/*": ["src/*"]
+      "@/*": ["./*"]
     }
   },
   "include": [


### PR DESCRIPTION
## Summary
- normalize artist handling to use IDs instead of names
- improve autocomplete with auto-create flow
- refactor upload service data types
- clean up admin upload screen for new artist objects
- fix TypeScript path alias

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_686eb34ac57883249f5b4e25a9ae5d2a