### PR TITLE
Fix track publishing and search playback

### DIFF
--- a/app/(tabs)/artist-dashboard.tsx
+++ b/app/(tabs)/artist-dashboard.tsx
@@ -230,7 +230,7 @@ export default function ArtistDashboardScreen() {
             styles.trackStatus,
             { color: item.is_published ? '#10b981' : '#f59e0b' }
           ]}>
-            {item.is_published ? 'Published' : 'Pending Approval'}
+            {item.is_published ? 'Published' : 'Draft'}
           </Text>
           <Text style={styles.trackStats}>
             {item.play_count || 0} plays

--- a/app/(tabs)/search.tsx
+++ b/app/(tabs)/search.tsx
@@ -104,9 +104,11 @@ export default function SearchScreen() {
 
       // For now, use mock data for other content types
       // In a real app, you'd search tracks, albums, etc. from your database
-      const mockTracks = trendingTracks.filter(track =>
-        track.title.toLowerCase().includes(searchQuery.toLowerCase()) ||
-        track.artist.toLowerCase().includes(searchQuery.toLowerCase())
+      const mockTracks = trendingTracks.filter(
+        track =>
+          (track.title.toLowerCase().includes(searchQuery.toLowerCase()) ||
+            track.artist.toLowerCase().includes(searchQuery.toLowerCase())) &&
+          track.is_published !== false // hide unpublished tracks
       );
 
       setResults({
@@ -146,9 +148,9 @@ export default function SearchScreen() {
   };
 
   const renderTrackItem = ({ item }: { item: any }) => (
-    <TouchableOpacity 
+    <TouchableOpacity
       style={styles.resultItem}
-      onPress={() => handleTrackPress(item)}
+      onPress={() => router.push(`/track/${item.id}`)}
     >
       <Image source={{ uri: item.coverUrl }} style={styles.resultImage} />
       <View style={styles.resultInfo}>
@@ -159,7 +161,10 @@ export default function SearchScreen() {
           {item.artist} • Song
         </Text>
       </View>
-      <TouchableOpacity style={styles.playButton}>
+      <TouchableOpacity
+        style={styles.playButton}
+        onPress={() => handleTrackPress(item)}
+      >
         {currentTrack?.id === item.id && isPlaying ? (
           <Pause color="#8b5cf6" size={20} />
         ) : (

--- a/app/admin/uploads.tsx
+++ b/app/admin/uploads.tsx
@@ -51,7 +51,12 @@ export default function AdminUploadsScreen() {
           id: single.id,
           title: single.title,
           type: 'single' as const,
-          artist: single.artist_id || single.artist || 'Unknown Artist',
+          artist:
+            single.artist?.name ||
+            single.artist_name ||
+            single.artist ||
+            single.artist_id ||
+            'Unknown Artist',
           coverUrl: single.cover_url || 'https://images.pexels.com/photos/167092/pexels-photo-167092.jpeg?auto=compress&cs=tinysrgb&w=400',
           releaseDate: single.release_date || single.created_at,
           duration: single.duration || 180,
@@ -62,7 +67,12 @@ export default function AdminUploadsScreen() {
           id: album.id,
           title: album.title,
           type: 'album' as const,
-          artist: album.artist_id || album.artist || 'Unknown Artist',
+          artist:
+            album.artist?.name ||
+            album.artist_name ||
+            album.artist ||
+            album.artist_id ||
+            'Unknown Artist',
           coverUrl: album.cover_url || 'https://images.pexels.com/photos/1699161/pexels-photo-1699161.jpeg?auto=compress&cs=tinysrgb&w=400',
           releaseDate: album.release_date || album.created_at,
           trackCount: album.track_count || album.tracks?.length || 0,
@@ -73,7 +83,12 @@ export default function AdminUploadsScreen() {
           id: track.id,
           title: track.title,
           type: 'track' as const,
-          artist: track.artist_id || track.artist || 'Unknown Artist',
+          artist:
+            track.artist?.name ||
+            track.artist_name ||
+            track.artist ||
+            track.artist_id ||
+            'Unknown Artist',
           coverUrl: track.cover_url || 'https://images.pexels.com/photos/167092/pexels-photo-167092.jpeg?auto=compress&cs=tinysrgb&w=400',
           releaseDate: track.release_date || track.created_at,
           duration: track.duration || 180,
@@ -158,7 +173,7 @@ export default function AdminUploadsScreen() {
             { backgroundColor: item.isPublished ? '#10b981' : '#f59e0b' }
           ]}>
             <Text style={styles.statusText}>
-              {item.isPublished ? 'Published' : 'Pending'}
+              {item.isPublished ? 'Published' : 'Draft'}
             </Text>
           </View>
         </View>

--- a/app/album/[id].tsx
+++ b/app/album/[id].tsx
@@ -54,7 +54,12 @@ export default function AlbumDetailScreen() {
       const transformedTracks = albumData.tracks?.map((track: any, index: number) => ({
         id: track.id,
         title: track.title,
-        artist: albumData.artist_id || albumData.artist || 'Unknown Artist',
+        artist:
+          albumData.artist?.name ||
+          albumData.artist_name ||
+          albumData.artist ||
+          albumData.artist_id ||
+          'Unknown Artist',
         album: albumData.title,
         duration: track.duration || 180,
         coverUrl: albumData.cover_url || 'https://images.pexels.com/photos/1699161/pexels-photo-1699161.jpeg?auto=compress&cs=tinysrgb&w=400',
@@ -268,7 +273,9 @@ export default function AlbumDetailScreen() {
           />
           
           <Text style={styles.albumTitle}>{album.title}</Text>
-          <Text style={styles.albumArtist}>{album.artist_id || album.artist}</Text>
+          <Text style={styles.albumArtist}>
+            {album.artist?.name || album.artist_name || album.artist_id || album.artist}
+          </Text>
           
           {album.description && (
             <Text style={styles.albumDescription}>{album.description}</Text>

--- a/app/artist/[id].tsx
+++ b/app/artist/[id].tsx
@@ -58,7 +58,12 @@ export default function ArtistDetailScreen() {
   const transformTrack = (apiTrack: any) => ({
     id: apiTrack.id,
     title: apiTrack.title,
-    artist: apiTrack.artist_id || apiTrack.artist || 'Unknown Artist',
+    artist:
+      apiTrack.artist?.name ||
+      apiTrack.artist_name ||
+      apiTrack.artist ||
+      apiTrack.artist_id ||
+      'Unknown Artist',
     album: apiTrack.album || 'Unknown Album',
     duration: apiTrack.duration,
     coverUrl: apiTrack.cover_url || 'https://images.pexels.com/photos/167092/pexels-photo-167092.jpeg?auto=compress&cs=tinysrgb&w=400',

--- a/app/single/[id].tsx
+++ b/app/single/[id].tsx
@@ -54,7 +54,12 @@ export default function SingleDetailScreen() {
       const transformedTrack = {
         id: singleData.id,
         title: singleData.title,
-        artist: singleData.artist_id || singleData.artist || 'Unknown Artist',
+        artist:
+          singleData.artist?.name ||
+          singleData.artist_name ||
+          singleData.artist ||
+          singleData.artist_id ||
+          'Unknown Artist',
         album: singleData.album || 'Single',
         duration: singleData.duration || 180,
         coverUrl: singleData.cover_url || 'https://images.pexels.com/photos/167092/pexels-photo-167092.jpeg?auto=compress&cs=tinysrgb&w=400',

--- a/app/track/[id].tsx
+++ b/app/track/[id].tsx
@@ -53,7 +53,12 @@ export default function TrackDetailScreen() {
   const transformTrack = (apiTrack: any) => ({
     id: apiTrack.id,
     title: apiTrack.title,
-    artist: apiTrack.artist_id || apiTrack.artist || 'Unknown Artist',
+    artist:
+      apiTrack.artist?.name ||
+      apiTrack.artist_name ||
+      apiTrack.artist ||
+      apiTrack.artist_id ||
+      'Unknown Artist',
     album: apiTrack.album || 'Unknown Album',
     duration: apiTrack.duration,
     coverUrl: apiTrack.cover_url || 'https://images.pexels.com/photos/167092/pexels-photo-167092.jpeg?auto=compress&cs=tinysrgb&w=400',

--- a/providers/MusicProvider.tsx
+++ b/providers/MusicProvider.tsx
@@ -177,8 +177,12 @@ export function MusicProvider({ children }: { children: React.ReactNode }) {
   };
 
   const playTrack = async (track: Track, newQueue?: Track[]) => {
+    // Debugging playback issues
+    console.log('▶️ playTrack called with URL:', track.audioUrl);
+
     setCurrentTrack(track);
     setIsPlaying(true);
+    console.log('📻 Now playing:', track.title);
     setDuration(track.duration);
     
     if (newQueue) {

--- a/services/uploadService.ts
+++ b/services/uploadService.ts
@@ -70,6 +70,14 @@ class UploadService {
       throw new Error('Not authenticated - please log in again');
     }
 
+    // Check if uploader is an admin so we can auto publish
+    const { data: userRecord } = await supabase
+      .from('users')
+      .select('role')
+      .eq('id', session.user.id)
+      .single();
+    const isAdmin = userRecord?.role === 'admin';
+
     console.log('🎵 Uploading single with Supabase Storage...');
 
     // Step 2: Upload audio file
@@ -99,7 +107,8 @@ class UploadService {
       explicit: singleData.explicit,
       description: singleData.description || '',
       release_date: singleData.releaseDate || new Date().toISOString().split('T')[0],
-      is_published: false,
+      // Auto publish if the uploader is an admin
+      is_published: isAdmin,
       track_number: 1,
       created_by: session.user.id,
       featured_artist_ids: singleData.featuredArtistIds,
@@ -144,6 +153,14 @@ class UploadService {
         throw new Error('Not authenticated - please log in again');
       }
 
+      // Determine if uploader is an admin for auto publishing
+      const { data: userRecord } = await supabase
+        .from('users')
+        .select('role')
+        .eq('id', session.user.id)
+        .single();
+      const isAdmin = userRecord?.role === 'admin';
+
       console.log('💿 Uploading album with Supabase Storage...');
 
       // Step 1: Upload album cover if provided
@@ -163,7 +180,8 @@ class UploadService {
         genres: albumData.genres,
         explicit: albumData.explicit,
         track_count: albumData.tracks.length,
-        is_published: false, // Admin approval required
+        // Auto publish if the uploader is an admin
+        is_published: isAdmin,
         created_by: session.user.id,
         featured_artist_ids: albumData.featuredArtistIds,
       };
@@ -207,7 +225,8 @@ class UploadService {
             genres: albumData.genres,
             explicit: track.explicit,
             track_number: track.trackNumber,
-            is_published: false, // Admin approval required
+            // Auto publish track if the uploader is an admin
+            is_published: isAdmin,
             created_by: session.user.id,
             featured_artist_ids: track.featuredArtistIds,
           };


### PR DESCRIPTION
## Summary
- auto publish tracks for admin uploads
- log audio URL when playing
- show artist name if available
- update status labels to "Draft" when not published
- filter search to hide unpublished tracks
- navigate to track details from search results

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_68712dc62d108324910581155ec9c128