### PR TITLE
Fix initial auth loading

### DIFF
--- a/providers/AuthProvider.tsx
+++ b/providers/AuthProvider.tsx
@@ -226,7 +226,9 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       setSession(initialSession);
       apiService.setAuthToken(initialSession?.access_token ?? '');
       if (initialSession?.user?.id) {
-        loadUserProfile(initialSession.user.id);
+        loadUserProfile(initialSession.user.id).finally(() => {
+          if (mounted) setIsLoading(false);
+        });
       } else {
         setIsLoading(false);
       }
@@ -239,11 +241,16 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
       switch (event) {
         case 'SIGNED_IN':
+        case 'INITIAL_SESSION':
           setSession(sess);
           apiService.setAuthToken(sess!.access_token);
-          loadUserProfile(sess!.user.id).finally(() => {
-            if (mounted) setIsLoading(false);
-          });
+          if (sess?.user?.id) {
+            loadUserProfile(sess.user.id).finally(() => {
+              if (mounted) setIsLoading(false);
+            });
+          } else {
+            setIsLoading(false);
+          }
           break;
 
         case 'SIGNED_OUT':


### PR DESCRIPTION
## Summary
- ensure we clear loading state after initial session load
- handle `INITIAL_SESSION` events in auth provider

## Testing
- `npm run lint` *(fails: fetch failed due to no internet)*

------
https://chatgpt.com/codex/tasks/task_e_687ccde4cec883248a3246546ade09b7