### PR TITLE
Refactor tabs and search

### DIFF
--- a/app/(tabs)/admin.tsx
+++ b/app/(tabs)/admin.tsx
@@ -187,12 +187,12 @@ export default function AdminScreen() {
                 onPress={() => router.push(act.route as any)}
               >
                 <LinearGradient
-                  colors={['#8b5cf6', '#a855f7']}
+                  colors={["#8b5cf6", "#a855f7"]}
                   style={styles.actionGradient}
                 >
                   <act.icon color="#fff" size={20} />
-                  <Text style={styles.actionText}>{act.label}</Text>
                 </LinearGradient>
+                <Text style={styles.actionText}>{act.label}</Text>
               </TouchableOpacity>
             ))}
           </View>
@@ -230,12 +230,41 @@ const styles = StyleSheet.create({
   section: { marginBottom: 32, paddingHorizontal: 24 },
   sectionTitle: { fontSize: 20, color: '#fff', marginBottom: 16, fontFamily: 'Poppins-SemiBold' },
   actionsRow: { flexDirection: 'row', justifyContent: 'space-between' },
-  actionBtn: { flex: 1, marginRight: 12, borderRadius: 12, overflow: 'hidden' },
-  actionGradient: { flexDirection: 'row', alignItems: 'center', justifyContent: 'center', padding: 12 },
-  actionText: { color: '#fff', marginLeft: 8, fontFamily: 'Inter-Medium' },
+  actionBtn: {
+    flex: 1,
+    marginRight: 12,
+    borderRadius: 12,
+    backgroundColor: 'rgba(255,255,255,0.05)',
+    padding: 12,
+    alignItems: 'center',
+  },
+  actionGradient: {
+    width: 36,
+    height: 36,
+    borderRadius: 18,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginBottom: 6,
+  },
+  actionText: { color: '#fff', fontFamily: 'Inter-Medium', fontSize: 12 },
   statsGrid: { flexDirection: 'row', flexWrap: 'wrap', justifyContent: 'space-between' },
-  card: { width: '47%', backgroundColor: 'rgba(255,255,255,0.05)', borderRadius: 12, padding: 16, alignItems: 'center', marginBottom: 12 },
-  cardIcon: { marginBottom: 8 },
+  card: {
+    width: '47%',
+    backgroundColor: 'rgba(255,255,255,0.05)',
+    borderRadius: 12,
+    padding: 16,
+    alignItems: 'center',
+    marginBottom: 12,
+  },
+  cardIcon: {
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+    backgroundColor: 'rgba(139,92,246,0.15)',
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginBottom: 8,
+  },
   cardValue: { fontSize: 22, color: '#fff', fontFamily: 'Poppins-Bold' },
   cardTitle: { fontSize: 14, color: '#94a3b8', fontFamily: 'Inter-Medium' },
   cardSubtitle: { fontSize: 12, color: '#10b981' },

--- a/app/(tabs)/admin/_layout.tsx
+++ b/app/(tabs)/admin/_layout.tsx
@@ -1,0 +1,5 @@
+import { Stack } from 'expo-router';
+
+export default function AdminStack() {
+  return <Stack screenOptions={{ headerShown: false }} />;
+}

--- a/app/(tabs)/search.tsx
+++ b/app/(tabs)/search.tsx
@@ -160,14 +160,75 @@ function SearchScreen() {
 
       {!isSearching && (
         <ScrollView style={styles.content}>
-          {query === '' ? (
-            <> ... </>
+          {query.trim() === '' ? (
+            <View style={styles.section}>
+              <Text style={styles.sectionTitle}>Trending Searches</Text>
+              <View style={styles.trendingContainer}>
+                {trendingSearches.map((t) => (
+                  <TouchableOpacity
+                    key={t}
+                    style={styles.trendingItem}
+                    onPress={() => handleTrendingPress(t)}
+                  >
+                    <Text style={styles.trendingText}>{t}</Text>
+                  </TouchableOpacity>
+                ))}
+              </View>
+            </View>
           ) : (
-            Object.entries(filteredResults).map(([key, arr]) => (
-              arr.length > 0 && key !== 'singles' && key !== 'artists' && (
-                <View key={key} style={styles.section}> ... </View>
-              )
-            ))
+            <>
+              {filteredResults.tracks && filteredResults.tracks.length > 0 && (
+                <View style={styles.section}>
+                  <Text style={styles.sectionTitle}>Songs</Text>
+                  {filteredResults.tracks.map((item) => (
+                    <View key={item.id}>{renderTrackItem({ item })}</View>
+                  ))}
+                </View>
+              )}
+
+              {filteredResults.artists && filteredResults.artists.length > 0 && (
+                <View style={styles.section}>
+                  <Text style={styles.sectionTitle}>Artists</Text>
+                  {filteredResults.artists.map((item: any) => (
+                    <TouchableOpacity
+                      key={item.id}
+                      style={styles.resultItem}
+                      onPress={() => router.push(`/artist/${item.id}`)}
+                    >
+                      <Image
+                        source={{
+                          uri:
+                            item.avatar_url ||
+                            'https://images.pexels.com/photos/771742/pexels-photo-771742.jpeg',
+                        }}
+                        style={styles.resultImage}
+                      />
+                      <View style={styles.resultInfo}>
+                        <Text style={styles.resultTitle}>{item.name}</Text>
+                        <Text style={styles.resultSubtitle}>Artist</Text>
+                      </View>
+                    </TouchableOpacity>
+                  ))}
+                </View>
+              )}
+
+              {filteredResults.users && filteredResults.users.length > 0 && (
+                <View style={styles.section}>
+                  <Text style={styles.sectionTitle}>Users</Text>
+                  {filteredResults.users.map((item) => (
+                    <View key={item.id}>{renderUserItem({ item })}</View>
+                  ))}
+                </View>
+              )}
+
+              {filteredResults.tracks?.length === 0 &&
+                filteredResults.artists?.length === 0 &&
+                filteredResults.users?.length === 0 && (
+                  <View style={styles.emptyState}>
+                    <Text style={styles.emptyText}>No results found</Text>
+                  </View>
+                )}
+            </>
           )}
         </ScrollView>
       )}
@@ -200,6 +261,8 @@ const styles = StyleSheet.create({
   playButton: { padding:8 },
   userMeta: { flexDirection:'row', alignItems:'center', justifyContent:'space-between' },
   privacyIndicator: { marginLeft:8 },
+  emptyState: { alignItems:'center', marginTop:40 },
+  emptyText: { color:'#94a3b8' },
   bottomPadding: { height:120 }
 });
 


### PR DESCRIPTION
## Summary
- hide admin upload routes behind stack layout
- redesign admin dashboard styles
- overhaul search screen with live results and empty states
- implement Supabase-powered search in `MusicProvider`

## Testing
- `npm run lint` *(fails: fetch failed due to network)*

------
https://chatgpt.com/codex/tasks/task_e_687d1390adf4832498e8bc9badafaa84