### PR TITLE
Add role-based tab visibility and search improvements

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -1,6 +1,6 @@
 import { Tabs } from 'expo-router';
 import { useAuth } from '@/providers/AuthProvider';
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
 import { router } from 'expo-router';
 import {
   Chrome as Home,
@@ -15,6 +15,7 @@ import { View, StyleSheet } from 'react-native';
 
 export default function TabLayout() {
   const { user, isLoading } = useAuth();
+  const role = user?.role;
 
   useEffect(() => {
     if (!isLoading && !user) {
@@ -22,15 +23,31 @@ export default function TabLayout() {
     }
   }, [user, isLoading]);
 
-  if (isLoading) {
-  return null; // Or <LoadingScreen />
-}
+  useEffect(() => {
+    if (user) {
+      console.log('[Tabs] user role', role);
+    }
+  }, [role, user]);
 
-if (!user) {
-  router.replace('/(auth)/login');
-  return null;
-}
+  if (isLoading || !user) {
+    return null; // Or <LoadingScreen />
+  }
 
+  const screens = [
+    { name: 'index', title: 'Home', icon: Home },
+    { name: 'search', title: 'Search', icon: Search },
+    { name: 'library', title: 'Library', icon: Library },
+  ];
+
+  if (role === 'artist') {
+    screens.push({ name: 'artist-dashboard', title: 'Upload', icon: Upload });
+  }
+
+  if (role === 'admin') {
+    screens.push({ name: 'admin', title: 'Admin', icon: Settings });
+  }
+
+  screens.push({ name: 'profile', title: 'Profile', icon: User });
 
   return (
     <View style={styles.container}>
@@ -53,76 +70,18 @@ if (!user) {
           },
         }}
       >
-        {/* Home tab - visible to all users */}
-        <Tabs.Screen
-          name="index"
-          options={{
-            title: 'Home',
-            tabBarIcon: ({ size, color }) => (
-              <Home size={size} color={color} />
-            ),
-          }}
-        />
-        
-        {/* Search tab - visible to all users */}
-        <Tabs.Screen
-          name="search"
-          options={{
-            title: 'Search',
-            tabBarIcon: ({ size, color }) => (
-              <Search size={size} color={color} />
-            ),
-          }}
-        />
-        
-        {/* Library tab - visible to all users */}
-        <Tabs.Screen
-          name="library"
-          options={{
-            title: 'Library',
-            tabBarIcon: ({ size, color }) => (
-              <Library size={size} color={color} />
-            ),
-          }}
-        />
-        
-        {/* Artist Dashboard - only visible to artists */}
-        {user?.role === 'artist' && (
+        {screens.map(({ name, title, icon: Icon }) => (
           <Tabs.Screen
-            name="artist-dashboard"
+            key={name}
+            name={name}
             options={{
-              title: 'Upload',
+              title,
               tabBarIcon: ({ size, color }) => (
-                <Upload size={size} color={color} />
+                <Icon size={size} color={color} />
               ),
             }}
           />
-        )}
-
-        {/* Admin Dashboard - only visible to admins */}
-        {user?.role === 'admin' && (
-          <Tabs.Screen
-            name="admin"
-            options={{
-              title: 'Admin',
-              tabBarIcon: ({ size, color }) => (
-                <Settings size={size} color={color} />
-              ),
-            }}
-          />
-        )}
-
-        
-        {/* Profile tab - visible to all users */}
-        <Tabs.Screen
-          name="profile"
-          options={{
-            title: 'Profile',
-            tabBarIcon: ({ size, color }) => (
-              <User size={size} color={color} />
-            ),
-          }}
-        />
+        ))}
       </Tabs>
       <MiniPlayer />
     </View>

--- a/app/(tabs)/admin/index.tsx
+++ b/app/(tabs)/admin/index.tsx
@@ -143,9 +143,9 @@ export default function AdminScreen() {
   }
 
   const quickActions = [
-    { label: 'Upload Content', icon: Upload, route: '/admin/upload' },
-    { label: 'View Uploads', icon: Plus, route: '/admin/uploads' },
-    { label: 'Manage Artists', icon: Users, route: '/admin/artists' },
+    { label: 'Upload Single', icon: Upload, route: '/admin/upload?type=single' },
+    { label: 'Upload Album', icon: Plus, route: '/admin/upload?type=album' },
+    { label: 'View Uploads', icon: Music, route: '/admin/uploads' },
   ] as const;
 
   const statsCards = [

--- a/app/(tabs)/admin/upload.tsx
+++ b/app/(tabs)/admin/upload.tsx
@@ -1,4 +1,6 @@
 import React, { useState, useEffect } from 'react';
+
+export const unstable_settings = { href: null };
 import {
   View,
   Text,

--- a/app/(tabs)/admin/uploads.tsx
+++ b/app/(tabs)/admin/uploads.tsx
@@ -1,4 +1,6 @@
 import React, { useState, useEffect } from 'react';
+
+export const unstable_settings = { href: null };
 import {
   View,
   Text,

--- a/app/(tabs)/search.tsx
+++ b/app/(tabs)/search.tsx
@@ -31,6 +31,7 @@ function SearchScreen() {
   });
   const [trendingSearches, setTrendingSearches] = useState<string[]>([]);
   const [isSearching, setIsSearching] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
   const {
     currentTrack,
@@ -63,6 +64,7 @@ function SearchScreen() {
 
   const handleSearch = async (searchQuery: string) => {
     setIsSearching(true);
+    setErrorMessage(null);
     try {
       const musicResults = await searchMusic(searchQuery);
       setResults({
@@ -72,6 +74,9 @@ function SearchScreen() {
         artists: musicResults.artists || [],
         users: musicResults.users || [],
       });
+    } catch (err) {
+      console.error('search error', err);
+      setErrorMessage('Something went wrong');
     } finally {
       setIsSearching(false);
     }
@@ -166,6 +171,12 @@ function SearchScreen() {
         </View>
       )}
 
+      {errorMessage && !isSearching && (
+        <View style={styles.errorContainer}>
+          <Text style={styles.errorText}>{errorMessage}</Text>
+        </View>
+      )}
+
       {!isSearching && (
         <ScrollView style={styles.content} showsVerticalScrollIndicator={false}>
           {query.trim() === '' ? (
@@ -247,6 +258,8 @@ const styles = StyleSheet.create({
   searchInput: { flex:1, marginLeft:8, color:'#fff' },
   loadingContainer: { flex:1, justifyContent:'center', alignItems:'center' },
   loadingText: { color:'#94a3b8', marginTop:12 },
+  errorContainer: { padding:24, alignItems:'center' },
+  errorText: { color:'#ef4444' },
   content: { flex:1 },
   section: { marginBottom:32, paddingHorizontal:24 },
   sectionTitle: { fontSize:20, color:'#fff', marginBottom:16 },

--- a/providers/AuthProvider.tsx
+++ b/providers/AuthProvider.tsx
@@ -82,7 +82,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
           console.log('[Auth] loadUserProfile: no changes, skip');
           return prev;
         }
-        console.log('[Auth] loadUserProfile success, updating');
+        console.log('[Auth] loadUserProfile success, role:', data.role);
         return data as Profile;
       });
     } catch (err) {


### PR DESCRIPTION
## Summary
- log profile roles when loaded
- hide admin upload screens from tabs
- conditionally build bottom tabs based on role
- tweak admin dashboard quick actions
- improve search screen error handling

## Testing
- `npm run lint` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_687d39fc81fc8324a1fae4b9b80e5c2a