### PR TITLE
Refactor upload flow and add scheduled publishing

### DIFF
--- a/app/(tabs)/admin/index.tsx
+++ b/app/(tabs)/admin/index.tsx
@@ -148,7 +148,7 @@ export default function AdminScreen() {
   const quickActions = [
     { label: 'Upload Single', icon: Upload, route: '/admin/upload?type=single' },
     { label: 'Upload Album', icon: Plus, route: '/admin/upload?type=album' },
-    { label: 'View Uploads', icon: Music, route: '/admin/upload' },
+    { label: 'View Uploads', icon: Music, route: '/admin/uploads' },
   ] as const;
 
   const statsCards = [
@@ -223,7 +223,7 @@ export default function AdminScreen() {
         <View style={styles.section}>
           <Text style={styles.sectionTitle}>Admin Tools</Text>
           <View style={styles.toolsList}>
-            <TouchableOpacity style={styles.toolCard} onPress={() => router.push('/admin/upload')}>
+            <TouchableOpacity style={styles.toolCard} onPress={() => router.push('/admin/uploads')}>
               <Music color="#8b5cf6" size={24} />
               <Text style={styles.toolText}>Manage Uploads</Text>
             </TouchableOpacity>

--- a/app/(tabs)/admin/uploads.tsx
+++ b/app/(tabs)/admin/uploads.tsx
@@ -1,0 +1,83 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, ScrollView, RefreshControl, TouchableOpacity, StyleSheet } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+import { useAuth } from '@/providers/AuthProvider';
+import { supabase } from '@/providers/AuthProvider';
+import { router } from 'expo-router';
+
+export default function UploadsScreen() {
+  const { user } = useAuth();
+  const [uploads, setUploads] = useState<any[]>([]);
+  const [refreshing, setRefreshing] = useState(false);
+
+  const loadUploads = async () => {
+    if (!user) return;
+    const { data } = await supabase
+      .from('tracks')
+      .select('id,title,is_published,album_id,created_at')
+      .eq('created_by', user.id)
+      .order('created_at', { ascending: false });
+    setUploads(data || []);
+  };
+
+  useEffect(() => {
+    loadUploads();
+  }, []);
+
+  const onRefresh = async () => {
+    setRefreshing(true);
+    await loadUploads();
+    setRefreshing(false);
+  };
+
+  return (
+    <LinearGradient colors={["#0f172a", "#111827", "#0b1120"]} style={{ flex: 1 }}>
+      <ScrollView
+        contentContainerStyle={{ padding: 20 }}
+        refreshControl={
+          <RefreshControl
+            refreshing={refreshing}
+            onRefresh={onRefresh}
+            tintColor="#8b5cf6"
+            colors={["#8b5cf6"]}
+          />
+        }
+      >
+        <Text style={styles.title}>My Uploads</Text>
+        {uploads.map((u) => (
+          <TouchableOpacity
+            key={u.id}
+            style={styles.item}
+            onPress={() => router.push(`/track/${u.id}`)}
+          >
+            <Text style={styles.itemTitle}>{u.title}</Text>
+            <Text style={styles.itemStatus}>
+              {u.is_published ? "Published" : "Unpublished"}
+            </Text>
+          </TouchableOpacity>
+        ))}
+        {uploads.length === 0 && (
+          <Text style={styles.empty}>No uploads yet.</Text>
+        )}
+      </ScrollView>
+    </LinearGradient>
+  );
+}
+
+const styles = StyleSheet.create({
+  title: {
+    color: "#fff",
+    fontSize: 24,
+    marginBottom: 20,
+    fontFamily: "Poppins-Bold",
+  },
+  item: {
+    backgroundColor: "rgba(255,255,255,0.05)",
+    padding: 12,
+    borderRadius: 8,
+    marginBottom: 12,
+  },
+  itemTitle: { color: "#fff", fontSize: 16 },
+  itemStatus: { color: "#94a3b8", fontSize: 12, marginTop: 4 },
+  empty: { color: "#94a3b8", marginTop: 20 },
+});

--- a/providers/MusicProvider.tsx
+++ b/providers/MusicProvider.tsx
@@ -227,6 +227,7 @@ export function MusicProvider({ children }: { children: React.ReactNode }) {
             'id,title,duration,cover_url,audio_url,artist_name,album:title,genres,release_date,created_at'
           )
           .ilike('title', `%${term}%`)
+          .eq('is_published', true)
           .limit(10),
         supabase
           .from('artists')

--- a/services/uploadService.ts
+++ b/services/uploadService.ts
@@ -17,6 +17,8 @@ export interface SingleUploadData {
   featuredArtistIds: string[];
   coverFile?: { uri: string; name?: string; type?: string };
   audioFile: { uri: string; name?: string; type?: string };
+  isPublished?: boolean;
+  scheduledPublishAt?: string | null;
 }
 
 export interface AlbumUploadData {
@@ -38,6 +40,8 @@ export interface AlbumUploadData {
     featuredArtistIds: string[];
     audioFile: { uri: string; name?: string; type?: string };
   }>;
+  isPublished?: boolean;
+  scheduledPublishAt?: string | null;
 }
 
 export interface UploadPermissions {
@@ -197,6 +201,8 @@ class UploadService {
           description: data.description || '',
           audio_url: audioUrl,
           cover_url: coverUrl,
+          is_published: data.isPublished ?? false,
+          scheduled_publish_at: data.scheduledPublishAt ?? null,
         });
       if (error) {
         console.error('[UploadService] supabase.insert track error', error);
@@ -237,6 +243,8 @@ class UploadService {
           created_by: data.artistId,
           featured_artist_ids: data.featuredArtistIds,
           cover_url: coverUrl,
+          is_published: data.isPublished ?? false,
+          scheduled_publish_at: data.scheduledPublishAt ?? null,
         });
       if (albumError) {
         console.error('[UploadService] supabase.insert album error', albumError);
@@ -269,6 +277,8 @@ class UploadService {
             description: data.description || '',
             audio_url: audioUrl,
             cover_url: null,
+            is_published: data.isPublished ?? false,
+            scheduled_publish_at: data.scheduledPublishAt ?? null,
           });
         if (trackError) {
           console.error('[UploadService] supabase.insert track for album error', trackError);

--- a/supabase/functions/publishScheduled.ts
+++ b/supabase/functions/publishScheduled.ts
@@ -1,0 +1,24 @@
+// @ts-nocheck
+import { serve } from 'https://deno.land/std@0.192.0/http/server.ts';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.39.0';
+
+serve(async () => {
+  const supabaseUrl = Deno.env.get('SUPABASE_URL')!;
+  const supabaseKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!;
+  const supabase = createClient(supabaseUrl, supabaseKey);
+  const now = new Date().toISOString();
+
+  await supabase
+    .from('tracks')
+    .update({ is_published: true })
+    .lte('scheduled_publish_at', now)
+    .eq('is_published', false);
+
+  await supabase
+    .from('albums')
+    .update({ is_published: true })
+    .lte('scheduled_publish_at', now)
+    .eq('is_published', false);
+
+  return new Response('ok');
+});

--- a/supabase/migrations/20250628000100_scheduled_publish.sql
+++ b/supabase/migrations/20250628000100_scheduled_publish.sql
@@ -1,0 +1,3 @@
+-- Add scheduled publishing columns
+ALTER TABLE tracks ADD COLUMN IF NOT EXISTS scheduled_publish_at timestamptz;
+ALTER TABLE albums ADD COLUMN IF NOT EXISTS scheduled_publish_at timestamptz;

--- a/types/env.d.ts
+++ b/types/env.d.ts
@@ -8,3 +8,5 @@ declare global {
 }
 
 export {};
+
+declare module '@react-native-community/datetimepicker';


### PR DESCRIPTION
## Summary
- add scheduled publish column migrations and edge function
- filter search results to only show published tracks
- create admin uploads listing screen
- enhance upload screen with scheduling options and better UI
- fix dashboard links to new uploads view

## Testing
- `npx tsc -p tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_e_687ec92e76208324ad1bc5ee5fcdb867