### PR TITLE
Fix dynamic data fetching and search

### DIFF
--- a/app/(tabs)/admin/index.tsx
+++ b/app/(tabs)/admin/index.tsx
@@ -7,6 +7,7 @@ import {
   ScrollView,
   ActivityIndicator,
   RefreshControl,
+  Modal,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { LinearGradient } from 'expo-linear-gradient';
@@ -150,13 +151,14 @@ export default function AdminScreen() {
     );
   }
 
+  const [showUploadMenu, setShowUploadMenu] = useState(false);
+
   const quickActions = [
     {
-      label: 'Upload Single',
+      label: 'Upload Music',
       icon: Upload,
-      route: '/admin/upload?type=single',
+      onPress: () => setShowUploadMenu(true),
     },
-    { label: 'Upload Album', icon: Plus, route: '/admin/upload?type=album' },
     { label: 'View Uploads', icon: Music, route: '/admin/uploads' },
   ] as const;
 
@@ -217,7 +219,9 @@ export default function AdminScreen() {
                 <TouchableOpacity
                   key={act.label}
                   style={styles.actionBtn}
-                  onPress={() => router.push(act.route as any)}
+                  onPress={() =>
+                    act.onPress ? act.onPress() : router.push(act.route as any)
+                  }
                 >
                   <LinearGradient
                     colors={['#8b5cf6', '#a855f7']}
@@ -286,6 +290,43 @@ export default function AdminScreen() {
           </View>
         </ScrollView>
       </SafeAreaView>
+      {showUploadMenu && (
+        <Modal
+          transparent
+          animationType="fade"
+          onRequestClose={() => setShowUploadMenu(false)}
+        >
+          <View style={styles.modalOverlay}>
+            <View style={styles.modalContent}>
+              <Text style={styles.modalTitle}>Upload Music</Text>
+              <TouchableOpacity
+                style={styles.modalButton}
+                onPress={() => {
+                  setShowUploadMenu(false);
+                  router.push('/admin/upload?type=single');
+                }}
+              >
+                <Text style={styles.modalButtonText}>Single</Text>
+              </TouchableOpacity>
+              <TouchableOpacity
+                style={styles.modalButton}
+                onPress={() => {
+                  setShowUploadMenu(false);
+                  router.push('/admin/upload?type=album');
+                }}
+              >
+                <Text style={styles.modalButtonText}>Album</Text>
+              </TouchableOpacity>
+              <TouchableOpacity
+                style={[styles.modalButton, { backgroundColor: 'transparent' }]}
+                onPress={() => setShowUploadMenu(false)}
+              >
+                <Text style={[styles.modalButtonText, { color: '#ef4444' }]}>Cancel</Text>
+              </TouchableOpacity>
+            </View>
+          </View>
+        </Modal>
+      )}
     </LinearGradient>
   );
 }
@@ -365,4 +406,39 @@ const styles = StyleSheet.create({
     borderRadius: 12,
   },
   toolText: { color: '#fff', fontFamily: 'Inter-Regular', fontSize: 16 },
+  modalOverlay: {
+    position: 'absolute',
+    top: 0,
+    bottom: 0,
+    left: 0,
+    right: 0,
+    backgroundColor: 'rgba(0,0,0,0.6)',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  modalContent: {
+    backgroundColor: '#1f2937',
+    padding: 24,
+    borderRadius: 12,
+    width: '80%',
+  },
+  modalTitle: {
+    color: '#fff',
+    fontSize: 18,
+    fontFamily: 'Poppins-SemiBold',
+    marginBottom: 12,
+    textAlign: 'center',
+  },
+  modalButton: {
+    backgroundColor: 'rgba(139,92,246,0.2)',
+    paddingVertical: 12,
+    borderRadius: 8,
+    marginBottom: 12,
+    alignItems: 'center',
+  },
+  modalButtonText: {
+    color: '#8b5cf6',
+    fontFamily: 'Inter-SemiBold',
+    fontSize: 16,
+  },
 });

--- a/app/(tabs)/admin/uploads.tsx
+++ b/app/(tabs)/admin/uploads.tsx
@@ -43,7 +43,8 @@ export default function UploadsScreen() {
       style={{ flex: 1 }}
     >
       <ScrollView
-        contentContainerStyle={{ padding: 20 }}
+        contentContainerStyle={{ padding: 20, paddingBottom: 120 }}
+        showsVerticalScrollIndicator={false}
         refreshControl={
           <RefreshControl
             refreshing={refreshing}

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -44,16 +44,24 @@ function ProfileScreen() {
   const [newBio, setNewBio] = useState('');
 
   useEffect(() => {
-    if (user) loadProfile();
+    const fetchUser = async () => {
+      const { data } = await supabase.auth.getUser();
+      const uid = data.user?.id || user?.id;
+      if (uid) {
+        await loadProfile(uid);
+      } else {
+        setIsLoading(false);
+      }
+    };
+    fetchUser();
   }, [user]);
 
-  const loadProfile = async () => {
-    if (!user) return;
+  const loadProfile = async (uid: string) => {
     setIsLoading(true);
     try {
       const { data, error } = await supabase.rpc(
         'get_user_profile_with_stats',
-        { target_user_id: user.id },
+        { target_user_id: uid },
       );
       if (error) throw error;
       if (data && data.length) {
@@ -70,7 +78,7 @@ function ProfileScreen() {
         .select(
           'id, email, display_name, bio, profile_picture_url, is_private'
         )
-        .eq('id', user.id)
+        .eq('id', uid)
         .single();
       if (prof) {
         setProfile({

--- a/providers/MusicProvider.tsx
+++ b/providers/MusicProvider.tsx
@@ -241,9 +241,7 @@ export function MusicProvider({ children }: { children: React.ReactNode }) {
       const [trackRes, artistRes, userRes] = await Promise.all([
         supabase
           .from('tracks')
-          .select(
-            'id,title,duration,cover_url,audio_url,artist_name,album:title,genres,release_date,created_at',
-          )
+          .select(`*, artist:artist_id(*), album:album_id(*)`)
           .ilike('title', `%${term}%`)
           .eq('is_published', true)
           .limit(10),
@@ -258,10 +256,10 @@ export function MusicProvider({ children }: { children: React.ReactNode }) {
       const tracks = (trackRes.data || []).map((t: any) => ({
         id: t.id,
         title: t.title,
-        artist: t.artist_name || 'Unknown Artist',
-        album: t.album || 'Single',
+        artist: t.artist?.name || t.artist_name || 'Unknown Artist',
+        album: t.album?.title || t.album_title || 'Single',
         duration: t.duration || 0,
-        coverUrl: t.cover_url,
+        coverUrl: t.cover_url || t.album?.cover_url || '',
         audioUrl: t.audio_url,
         isLiked: likedSongs.some((l) => l.id === t.id),
         genre: Array.isArray(t.genres) ? t.genres[0] : t.genres || '',

--- a/services/api.ts
+++ b/services/api.ts
@@ -91,12 +91,8 @@ class ApiService {
         .from('albums')
         .select(
           `
-          id,
-          title,
-          artist:artist_name,
-          cover_url,
-          description,
-          release_date,
+          *,
+          artist:artist_id(*),
           tracks (
             id,
             title,
@@ -108,7 +104,7 @@ class ApiService {
             lyrics
           )
         `,
-        ) // ← closed backtick
+        )
         .eq('id', id) // ← filter by album id
         .single(); // ← expect a single row
 
@@ -153,7 +149,7 @@ class ApiService {
   async getArtistTracks(id: string): Promise<any[]> {
     const { data, error } = await supabase
       .from('tracks')
-      .select('*')
+      .select('*, artist:artist_id(*), album:album_id(*)')
       .eq('artist_id', id)
       .order('created_at', { ascending: false });
     if (error) throw error;


### PR DESCRIPTION
## Summary
- fetch full album and artist data from Supabase
- include nested album and artist metadata in track searches
- load profile using `supabase.auth.getUser`
- combine admin upload actions into one menu
- pad uploads screen for scrolling

## Testing
- `npm run lint` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_687efacee8888324b853aa4a432bf5ef