### PR TITLE
Fix track screen param parsing and playback errors

### DIFF
--- a/app/track/[id].tsx
+++ b/app/track/[id].tsx
@@ -47,7 +47,8 @@ export default function TrackDetailScreen() {
   }
 
   const router = useRouter();
-  const { id } = useLocalSearchParams<{ id: string }>();
+  const params = useLocalSearchParams();
+  const id = typeof params.id === 'string' ? params.id : undefined;
 
   if (!id) {
     Alert.alert('Error', 'Track ID is missing');

--- a/providers/MusicProvider.tsx
+++ b/providers/MusicProvider.tsx
@@ -6,6 +6,7 @@ import React, {
   useRef,
 } from 'react';
 import { Audio, AVPlaybackStatus } from 'expo-av';
+import { Alert } from 'react-native';
 import { supabase } from '@/services/supabase';
 import { useAuth } from './AuthProvider';
 
@@ -170,6 +171,8 @@ export function MusicProvider({ children }: { children: React.ReactNode }) {
       setQueue(queueParam.length ? queueParam : [track]);
     } catch (err) {
       console.error('playTrack error', err);
+      Alert.alert('Playback Error', 'Unable to play this track.');
+      setError((err as Error).message);
     }
   };
 


### PR DESCRIPTION
## Summary
- fix parsing of track id search param
- alert user on playback failure

## Testing
- `npm run lint` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_687f0787c8ec8324942e4f52a0bdd03e