### PR TITLE
Fix upload flow and page rendering

### DIFF
--- a/app/(tabs)/admin/index.tsx
+++ b/app/(tabs)/admin/index.tsx
@@ -152,14 +152,18 @@ export default function AdminScreen() {
     );
   }
 
-  const quickActions = [
+  type Action =
+    | { label: string; icon: any; onPress: () => void; route?: never }
+    | { label: string; icon: any; route: string; onPress?: never };
+
+  const quickActions: Action[] = [
     {
       label: 'Upload Music',
       icon: Upload,
       onPress: () => setShowUploadMenu(true),
     },
     { label: 'View Uploads', icon: Music, route: '/admin/uploads' },
-  ] as const;
+  ];
 
   const statsCards = [
     {

--- a/app/(tabs)/admin/upload.tsx
+++ b/app/(tabs)/admin/upload.tsx
@@ -24,7 +24,8 @@ import { useAuth } from '@/providers/AuthProvider';
 export default function UploadScreen() {
   const { user } = useAuth();
   const isAdmin = user?.role === 'admin';
-  const { isUploading, uploadProgress, uploadSingle, uploadAlbum } = useUpload();
+  const { isUploading, uploadProgress, uploadSingle, uploadAlbum } =
+    useUpload();
 
   const [mode, setMode] = useState<'single' | 'album'>('single');
   const [title, setTitle] = useState('');
@@ -34,7 +35,9 @@ export default function UploadScreen() {
   );
   const [mainArtist, setMainArtist] = useState<any>(null);
   const [coverFile, setCoverFile] = useState<any>(null);
-  const [publishMode, setPublishMode] = useState<'now' | 'schedule' | 'draft'>('now');
+  const [publishMode, setPublishMode] = useState<'now' | 'schedule' | 'draft'>(
+    'now',
+  );
   const [scheduledAt, setScheduledAt] = useState<Date | null>(null);
   const [showPicker, setShowPicker] = useState(false);
   const [published, setPublished] = useState(false);
@@ -69,19 +72,32 @@ export default function UploadScreen() {
     const res = await ImagePicker.launchImageLibraryAsync({
       mediaTypes: ImagePicker.MediaTypeOptions.Images,
     });
-    if (!res.canceled && res.assets?.[0]) setCoverFile(res.assets[0]);
+    if (!res.canceled && res.assets?.[0]) {
+      const a = res.assets[0];
+      setCoverFile({ ...a, type: a.mimeType });
+    }
   };
 
   const pickSingleAudio = async () => {
-    const res = await DocumentPicker.getDocumentAsync({ type: 'audio/*' });
-    if (!res.canceled && res.assets?.[0]) setAudioFile(res.assets[0]);
+    const res = await DocumentPicker.getDocumentAsync({
+      type: 'audio/*',
+      copyToCacheDirectory: true,
+    });
+    if (!res.canceled && res.assets?.[0]) {
+      const a = res.assets[0];
+      setAudioFile({ uri: a.uri, name: a.name, type: a.mimeType });
+    }
   };
 
   const pickTrackAudio = async (idx: number) => {
-    const res = await DocumentPicker.getDocumentAsync({ type: 'audio/*' });
+    const res = await DocumentPicker.getDocumentAsync({
+      type: 'audio/*',
+      copyToCacheDirectory: true,
+    });
     if (!res.canceled && res.assets?.[0]) {
+      const a = res.assets[0];
       const arr = [...tracks];
-      arr[idx].audioFile = res.assets[0];
+      arr[idx].audioFile = { uri: a.uri, name: a.name, type: a.mimeType };
       setTracks(arr);
     }
   };
@@ -180,7 +196,10 @@ export default function UploadScreen() {
   const handleDelete = async () => {
     if (!newId) return;
     try {
-      await apiService.deleteContent(mode === 'album' ? 'album' : 'track', newId);
+      await apiService.deleteContent(
+        mode === 'album' ? 'album' : 'track',
+        newId,
+      );
       Alert.alert('Deleted');
     } catch (err: any) {
       Alert.alert('Error', err.message);
@@ -206,7 +225,10 @@ export default function UploadScreen() {
   };
 
   return (
-    <LinearGradient colors={['#1a1a2e', '#16213e', '#0f3460']} style={styles.container}>
+    <LinearGradient
+      colors={['#1a1a2e', '#16213e', '#0f3460']}
+      style={styles.container}
+    >
       <ScrollView contentContainerStyle={styles.content}>
         <View style={[styles.section, styles.card, styles.toggleRow]}>
           {['single', 'album'].map((t) => (
@@ -215,7 +237,9 @@ export default function UploadScreen() {
               style={[styles.toggleBtn, mode === t && styles.toggleBtnActive]}
               onPress={() => setMode(t as any)}
             >
-              <Text style={styles.toggleText}>{t === 'single' ? 'Single' : 'Album'}</Text>
+              <Text style={styles.toggleText}>
+                {t === 'single' ? 'Single' : 'Album'}
+              </Text>
             </TouchableOpacity>
           ))}
         </View>
@@ -344,7 +368,11 @@ export default function UploadScreen() {
               onPress={() => setPublishMode(opt as any)}
             >
               <Text style={styles.toggleText}>
-                {opt === 'now' ? 'Publish Now' : opt === 'schedule' ? 'Schedule' : 'Draft'}
+                {opt === 'now'
+                  ? 'Publish Now'
+                  : opt === 'schedule'
+                    ? 'Schedule'
+                    : 'Draft'}
               </Text>
             </TouchableOpacity>
           ))}
@@ -356,7 +384,9 @@ export default function UploadScreen() {
               onPress={() => setShowPicker(true)}
             >
               <Text style={styles.fileBtnText}>
-                {scheduledAt ? scheduledAt.toLocaleString() : 'Pick Date & Time'}
+                {scheduledAt
+                  ? scheduledAt.toLocaleString()
+                  : 'Pick Date & Time'}
               </Text>
             </TouchableOpacity>
             {showPicker && (
@@ -371,13 +401,24 @@ export default function UploadScreen() {
             )}
           </View>
         )}
-        <TouchableOpacity style={styles.submitBtn} onPress={handleSubmit} disabled={isUploading}>
-          <Text style={styles.submitText}>{isUploading ? 'Uploading...' : 'Upload'}</Text>
+        <TouchableOpacity
+          style={styles.submitBtn}
+          onPress={handleSubmit}
+          disabled={isUploading}
+        >
+          <Text style={styles.submitText}>
+            {isUploading ? 'Uploading...' : 'Upload'}
+          </Text>
         </TouchableOpacity>
         {uploadDone && isAdmin && newId && (
           <View style={styles.adminActions}>
-            <TouchableOpacity style={styles.actionBtn} onPress={handleTogglePublish}>
-              <Text style={styles.actionText}>{published ? 'Unpublish' : 'Publish'}</Text>
+            <TouchableOpacity
+              style={styles.actionBtn}
+              onPress={handleTogglePublish}
+            >
+              <Text style={styles.actionText}>
+                {published ? 'Unpublish' : 'Publish'}
+              </Text>
             </TouchableOpacity>
             <TouchableOpacity style={styles.actionBtn} onPress={handleDelete}>
               <Text style={styles.actionText}>Delete</Text>

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -75,9 +75,7 @@ function ProfileScreen() {
       // fallback to basic profile
       const { data: prof } = await supabase
         .from('users')
-        .select(
-          'id, email, display_name, bio, profile_picture_url, is_private'
-        )
+        .select('id, email, display_name, bio, profile_picture_url, is_private')
         .eq('id', uid)
         .single();
       if (prof) {
@@ -105,9 +103,11 @@ function ProfileScreen() {
 
   const onRefresh = useCallback(async () => {
     setIsRefreshing(true);
-    await loadProfile();
+    if (user?.id) {
+      await loadProfile(user.id);
+    }
     setIsRefreshing(false);
-  }, []);
+  }, [user]);
 
   const togglePrivacy = async () => {
     if (!user) return;

--- a/app/single/[id].tsx
+++ b/app/single/[id].tsx
@@ -46,7 +46,14 @@ interface SingleData {
 }
 
 export default function SingleDetailScreen() {
-  const { id } = useLocalSearchParams<{ id: string }>();
+  const { id } = useLocalSearchParams();
+  if (!id || typeof id !== 'string') {
+    return (
+      <View style={styles.centered}>
+        <Text>Loading...</Text>
+      </View>
+    );
+  }
   const [single, setSingle] = useState<SingleData | null>(null);
   const [track, setTrack] = useState<SingleData | null>(null);
   const [isLoading, setIsLoading] = useState(true);
@@ -62,7 +69,7 @@ export default function SingleDetailScreen() {
     setIsLoading(true);
     setError(null);
     try {
-      const singleData = await apiService.getTrackById(id!);
+      const singleData = await apiService.getSingleById(id as string);
       setSingle(singleData);
       const prepared: SingleData = {
         id: singleData.id,
@@ -168,7 +175,12 @@ export default function SingleDetailScreen() {
             <Heart color="#fff" size={24} />
           </TouchableOpacity>
           <TouchableOpacity onPress={handlePlayPause} style={styles.playBtn}>
-            {currentTrack?.id === track.id && isPlaying ? <Pause color="#fff" size={32}/> : <Play color="#fff" size={32}/>}          </TouchableOpacity>
+            {currentTrack?.id === track.id && isPlaying ? (
+              <Pause color="#fff" size={32} />
+            ) : (
+              <Play color="#fff" size={32} />
+            )}
+          </TouchableOpacity>
           <TouchableOpacity onPress={handleAddToQueue} style={styles.controlBtn}>
             <Plus color="#fff" size={24} />
           </TouchableOpacity>

--- a/app/track/[id].tsx
+++ b/app/track/[id].tsx
@@ -47,12 +47,13 @@ export default function TrackDetailScreen() {
   }
 
   const router = useRouter();
-  const params = useLocalSearchParams();
-  const id = typeof params.id === 'string' ? params.id : undefined;
-
-  if (!id) {
-    Alert.alert('Error', 'Track ID is missing');
-    return null;
+  const { id } = useLocalSearchParams();
+  if (!id || typeof id !== 'string') {
+    return (
+      <View style={styles.loadingContainer}>
+        <ActivityIndicator />
+      </View>
+    );
   }
 
   const [track, setTrack] = useState<Track | null>(null);

--- a/services/api.ts
+++ b/services/api.ts
@@ -134,6 +134,19 @@ class ApiService {
     return data;
   }
 
+  /**
+   * Fetch single by ID and join its track
+   */
+  async getSingleById(id: string): Promise<any> {
+    const { data, error } = await supabase
+      .from('singles')
+      .select(`*, artist:artist_id(*), track:track_id(*)`)
+      .eq('id', id)
+      .single();
+    if (error) throw error;
+    return data;
+  }
+
   /** Get artist info */
   async getArtistById(id: string): Promise<any> {
     const { data, error } = await supabase

--- a/services/supabaseStorage.ts
+++ b/services/supabaseStorage.ts
@@ -1,6 +1,7 @@
 // Use the shared Supabase client from the AuthProvider so uploads are
 // authenticated with the current user session.
 import { supabase } from './supabase';
+import * as FileSystem from 'expo-file-system';
 
 /**
  * Upload a file to Supabase Storage and return its public URL
@@ -11,8 +12,11 @@ async function uploadFile(
   bucket: string = 'audio-files',
 ): Promise<{ url: string }> {
   // Fetch the file URI as a blob (React Native)
+  const info = await FileSystem.getInfoAsync(file.uri);
+  console.log('[supabaseStorage] local file size', (info as any).size ?? 'unknown');
   const response = await fetch(file.uri);
   const blob = await response.blob();
+  console.log('[supabaseStorage] blob size', blob.size);
 
   // Upload to Supabase Storage
   const { error: uploadError } = await supabase.storage


### PR DESCRIPTION
## Summary
- correct file picker and upload logic for Supabase
- add safety checks for single and track screens
- load singles from `singles` table
- new helper `getSingleById`

## Testing
- `npx tsc -p tsconfig.json`
- `npm run lint` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_687f0d81d65083249aa1ab8029de4ee6