### PR TITLE
Add Supabase upload helpers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54,6 +54,7 @@
       },
       "devDependencies": {
         "@babel/core": "^7.25.2",
+        "@types/mime": "^3.0.4",
         "@types/react": "~19.0.10",
         "@types/uuid": "^10.0.0",
         "babel-plugin-module-resolver": "^5.0.2",
@@ -3255,6 +3256,13 @@
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/mime": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-3.0.4.tgz",
+      "integrity": "sha512-iJt33IQnVRkqeqC7PzBHPTC6fDlRNRW8vjrgqtScAhrmMwe8c4Eo7+fUGTa+XdWrpEgpyKWMYmi2dIwMAYRzPw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/node": {

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",
+    "@types/mime": "^3.0.4",
     "@types/react": "~19.0.10",
     "@types/uuid": "^10.0.0",
     "babel-plugin-module-resolver": "^5.0.2",

--- a/services/uploadHelpers.ts
+++ b/services/uploadHelpers.ts
@@ -1,0 +1,60 @@
+import * as ImagePicker from 'expo-image-picker';
+import * as DocumentPicker from 'expo-document-picker';
+import { supabase } from '@/services/supabase';
+import mime from 'mime';
+
+export const uploadToSupabase = async (
+  fileUri: string,
+  path: string,
+  bucket: string,
+): Promise<string | null> => {
+  try {
+    const blob = await fetch(fileUri).then((res) => res.blob());
+    const contentType = mime.getType(fileUri) || 'application/octet-stream';
+
+    const { error } = await supabase.storage.from(bucket).upload(path, blob, {
+      cacheControl: '3600',
+      upsert: true,
+      contentType,
+    });
+
+    if (error) {
+      console.error('Upload failed:', error);
+      return null;
+    }
+
+    const { data } = supabase.storage.from(bucket).getPublicUrl(path);
+    const publicUrl = data.publicUrl;
+    console.log('✅ Upload success:', publicUrl);
+    return publicUrl;
+  } catch (err) {
+    console.error('Upload error:', err);
+    return null;
+  }
+};
+
+export const pickAndUploadImage = async () => {
+  const result = await ImagePicker.launchImageLibraryAsync({
+    mediaTypes: ImagePicker.MediaTypeOptions.Images,
+    allowsEditing: true,
+    quality: 1,
+  });
+
+  if (!result.canceled && result.assets && result.assets[0]) {
+    const uri = result.assets[0].uri;
+    const fileName = uri.split('/').pop();
+    const uploadPath = `covers/${fileName}`;
+    return uploadToSupabase(uri, uploadPath, 'images');
+  }
+  return null;
+};
+
+export const pickAndUploadAudio = async () => {
+  const result = await DocumentPicker.getDocumentAsync({ type: 'audio/*' });
+  if (!result.canceled && result.assets && result.assets[0]) {
+    const asset = result.assets[0];
+    const uploadPath = `track/${asset.name}`;
+    return uploadToSupabase(asset.uri, uploadPath, 'audio-files');
+  }
+  return null;
+};


### PR DESCRIPTION
## Summary
- add helper utilities for uploading files to Supabase
- track upload helpers in package.json

## Testing
- `npx tsc -p tsconfig.json`
- `npm run lint` *(fails: CONNECT api.expo.dev blocked)*

------
https://chatgpt.com/codex/tasks/task_e_687f126662f88324b9d835232a8b2f35