### PR TITLE
Fix session callback typings

### DIFF
--- a/providers/AuthProvider.tsx
+++ b/providers/AuthProvider.tsx
@@ -111,7 +111,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         await loadUserProfile(uid);
       }
     },
-    [loadUserProfile, syncSession],
+    [loadUserProfile],
   );
 
   const login = useCallback(

--- a/types/mime.d.ts
+++ b/types/mime.d.ts
@@ -1,0 +1,1 @@
+declare module 'mime';


### PR DESCRIPTION
## Summary
- avoid recursion in `syncSession` dependency list
- add stub `mime` declaration for consistent typing

## Testing
- `npx tsc -noEmit`
- `npx eslint .` *(fails: ESLint couldn't find a config file)*

------
https://chatgpt.com/codex/tasks/task_e_687f793720ec8324941a88cd87173d14