### PR TITLE
Fix uploads using buffer conversion

### DIFF
--- a/services/supabaseStorage.ts
+++ b/services/supabaseStorage.ts
@@ -2,6 +2,7 @@
 // authenticated with the current user session.
 import { supabase } from './supabase';
 import * as FileSystem from 'expo-file-system';
+import { Buffer } from 'buffer';
 
 /**
  * Upload a file to Supabase Storage and return its public URL
@@ -14,8 +15,11 @@ async function uploadFile(
   // Fetch the file URI as a blob (React Native)
   const info = await FileSystem.getInfoAsync(file.uri);
   console.log('[supabaseStorage] local file size', (info as any).size ?? 'unknown');
-  const response = await fetch(file.uri);
-  const blob = await response.blob();
+  const base64 = await FileSystem.readAsStringAsync(file.uri, {
+    encoding: FileSystem.EncodingType.Base64,
+  });
+  const buffer = Buffer.from(base64, 'base64');
+  const blob = new Blob([buffer], { type: file.type });
   console.log('[supabaseStorage] blob size', blob.size);
 
   // Upload to Supabase Storage

--- a/services/uploadHelpers.ts
+++ b/services/uploadHelpers.ts
@@ -1,6 +1,8 @@
 import * as ImagePicker from 'expo-image-picker';
 import * as DocumentPicker from 'expo-document-picker';
 import { supabase } from '@/services/supabase';
+import * as FileSystem from 'expo-file-system';
+import { Buffer } from 'buffer';
 import mime from 'mime';
 
 export const uploadToSupabase = async (
@@ -9,8 +11,14 @@ export const uploadToSupabase = async (
   bucket: string,
 ): Promise<string | null> => {
   try {
-    const blob = await fetch(fileUri).then((res) => res.blob());
-    const contentType = mime.getType(fileUri) || 'application/octet-stream';
+    const base64 = await FileSystem.readAsStringAsync(fileUri, {
+      encoding: FileSystem.EncodingType.Base64,
+    });
+    const buffer = Buffer.from(base64, 'base64');
+    const blob = new Blob([buffer], {
+      type: mime.getType(fileUri) || 'application/octet-stream',
+    });
+    const contentType = blob.type;
 
     const { error } = await supabase.storage.from(bucket).upload(path, blob, {
       cacheControl: '3600',


### PR DESCRIPTION
## Summary
- convert local files to blobs via `readAsStringAsync` before uploading
- apply conversion logic to generic upload helper

## Testing
- `npm run lint` *(fails: Cannot find module 'eslint')*

------
https://chatgpt.com/codex/tasks/task_e_687f7f1fc3f88324b60f551c02783888