### PR TITLE
Fix Supabase upload handling

### DIFF
--- a/app/(tabs)/admin/uploads.tsx
+++ b/app/(tabs)/admin/uploads.tsx
@@ -7,6 +7,7 @@ import {
   TouchableOpacity,
   StyleSheet,
 } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { LinearGradient } from 'expo-linear-gradient';
 import { useAuth } from '@/providers/AuthProvider';
 import { supabase } from '@/services/supabase';
@@ -42,8 +43,13 @@ export default function UploadsScreen() {
       colors={['#0f172a', '#111827', '#0b1120']}
       style={{ flex: 1 }}
     >
-      <ScrollView
-        contentContainerStyle={{ padding: 20, paddingBottom: 120 }}
+      <SafeAreaView style={{ flex: 1 }}>
+        <ScrollView
+          contentContainerStyle={{
+            paddingHorizontal: 20,
+            paddingTop: 20,
+            paddingBottom: 120,
+          }}
         showsVerticalScrollIndicator={false}
         refreshControl={
           <RefreshControl
@@ -70,7 +76,8 @@ export default function UploadsScreen() {
         {uploads.length === 0 && (
           <Text style={styles.empty}>No uploads yet.</Text>
         )}
-      </ScrollView>
+        </ScrollView>
+      </SafeAreaView>
     </LinearGradient>
   );
 }

--- a/services/supabaseStorage.ts
+++ b/services/supabaseStorage.ts
@@ -2,7 +2,6 @@
 // authenticated with the current user session.
 import { supabase } from './supabase';
 import * as FileSystem from 'expo-file-system';
-import { Buffer } from 'buffer';
 
 /**
  * Upload a file to Supabase Storage and return its public URL
@@ -14,12 +13,15 @@ async function uploadFile(
 ): Promise<{ url: string }> {
   // Fetch the file URI as a blob (React Native)
   const info = await FileSystem.getInfoAsync(file.uri);
-  console.log('[supabaseStorage] local file size', (info as any).size ?? 'unknown');
-  const base64 = await FileSystem.readAsStringAsync(file.uri, {
-    encoding: FileSystem.EncodingType.Base64,
-  });
-  const buffer = Buffer.from(base64, 'base64');
-  const blob = new Blob([buffer], { type: file.type });
+  console.log(
+    '[supabaseStorage] local file size',
+    (info as any).size ?? 'unknown',
+  );
+  const res = await fetch(file.uri);
+  if (!res.ok) {
+    throw new Error('Unable to read file for upload');
+  }
+  const blob = await res.blob();
   console.log('[supabaseStorage] blob size', blob.size);
 
   // Upload to Supabase Storage

--- a/services/uploadService.ts
+++ b/services/uploadService.ts
@@ -142,7 +142,7 @@ class UploadService {
     }
 
     const ext = file.name?.split('.').pop() || 'jpg';
-    const path = `images/${artistId}/${prefix}/${entityId}-cover.${ext}`;
+    const path = `covers/${entityId}.${ext}`;
     console.log('[UploadService] cover path', path);
 
     try {
@@ -161,10 +161,9 @@ class UploadService {
     trackId: string,
     albumId?: string,
   ): Promise<string> {
-    const base = albumId
-      ? `audio/${artistId}/albums/${albumId}`
-      : `audio/${artistId}/singles`;
-    const path = `${base}/${trackId}.mp3`;
+    const base = albumId ? `track/${albumId}` : 'track';
+    const ext = file.name?.split('.').pop() || 'mp3';
+    const path = `${base}/${trackId}.${ext}`;
     console.log('[UploadService] uploadTrackAudio start, path=', path, file);
 
     try {


### PR DESCRIPTION
## Summary
- ensure file blobs are uploaded correctly by fetching the local URI
- store covers under `images/covers` and tracks under `audio-files/track`
- wrap uploads list in `SafeAreaView`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687f82e515888324b95a8ef80b7a4c8e