### PR TITLE
Integrate Supabase playback and library features

### DIFF
--- a/app/(tabs)/library.tsx
+++ b/app/(tabs)/library.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import {
   View,
   Text,
@@ -22,8 +22,10 @@ import {
   X,
 } from 'lucide-react-native';
 import { withAuthGuard } from '@/hoc/withAuthGuard';
+import { useLocalSearchParams } from 'expo-router';
 
 function LibraryScreen() {
+  const { playlist } = useLocalSearchParams<{ playlist?: string }>();
   const [activeTab, setActiveTab] = useState('playlists');
   const [showCreatePlaylist, setShowCreatePlaylist] = useState(false);
   const [playlistName, setPlaylistName] = useState('');
@@ -38,7 +40,12 @@ function LibraryScreen() {
     playTrack,
     pauseTrack,
     createPlaylist,
+    toggleLike,
   } = useMusic();
+
+  useEffect(() => {
+    if (playlist) setActiveTab('playlists');
+  }, [playlist]);
 
   const handleCreatePlaylist = () => {
     if (!playlistName.trim()) {
@@ -64,6 +71,7 @@ function LibraryScreen() {
     <TouchableOpacity
       style={styles.trackItem}
       onPress={() => handleTrackPress(item)}
+      onLongPress={() => toggleLike(item.id)}
     >
       <Image source={{ uri: item.coverUrl }} style={styles.trackCover} />
       <View style={styles.trackInfo}>
@@ -140,10 +148,7 @@ function LibraryScreen() {
         {tabs.map((tab) => (
           <TouchableOpacity
             key={tab.id}
-            style={[
-              styles.tab,
-              activeTab === tab.id && styles.activeTab,
-            ]}
+            style={[styles.tab, activeTab === tab.id && styles.activeTab]}
             onPress={() => setActiveTab(tab.id)}
           >
             <tab.icon

--- a/app/(tabs)/search.tsx
+++ b/app/(tabs)/search.tsx
@@ -13,7 +13,17 @@ import {
 import { LinearGradient } from 'expo-linear-gradient';
 import { useMusic } from '@/providers/MusicProvider';
 import { router } from 'expo-router';
-import { Search, Play, Pause, Music, User, Disc, Users, Lock, Globe } from 'lucide-react-native';
+import {
+  Search,
+  Play,
+  Pause,
+  Music,
+  User,
+  Disc,
+  Users,
+  Lock,
+  Globe,
+} from 'lucide-react-native';
 import { withAuthGuard } from '@/hoc/withAuthGuard';
 
 interface SearchResults {
@@ -27,12 +37,18 @@ interface SearchResults {
 function SearchScreen() {
   const [query, setQuery] = useState('');
   const [results, setResults] = useState<SearchResults>({
-    tracks: [], albums: [], singles: [], artists: [], users: []
+    tracks: [],
+    albums: [],
+    singles: [],
+    artists: [],
+    users: [],
   });
   const [trendingSearches, setTrendingSearches] = useState<string[]>([]);
   const [isSearching, setIsSearching] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
-  const [sort, setSort] = useState<'relevance' | 'recent' | 'popular'>('relevance');
+  const [sort, setSort] = useState<'relevance' | 'recent' | 'popular'>(
+    'relevance',
+  );
   const [genre, setGenre] = useState<string | null>(null);
 
   const {
@@ -42,14 +58,20 @@ function SearchScreen() {
     pauseTrack,
     trendingTracks,
     searchMusic,
-    error
+    error,
   } = useMusic();
 
   useEffect(() => {
     const load = async () => {
       setTrendingSearches([
-        'Electronic Music', 'Chill Vibes', 'Hip Hop', 'Indie Rock',
-        'Jazz', 'Classical', 'Pop Hits', 'R&B'
+        'Electronic Music',
+        'Chill Vibes',
+        'Hip Hop',
+        'Indie Rock',
+        'Jazz',
+        'Classical',
+        'Pop Hits',
+        'R&B',
       ]);
     };
     load();
@@ -57,7 +79,13 @@ function SearchScreen() {
 
   useEffect(() => {
     if (!query.trim()) {
-      setResults({ tracks: [], albums: [], singles: [], artists: [], users: [] });
+      setResults({
+        tracks: [],
+        albums: [],
+        singles: [],
+        artists: [],
+        users: [],
+      });
       return;
     }
     const timer = setTimeout(() => handleSearch(query), 300);
@@ -68,7 +96,10 @@ function SearchScreen() {
     setIsSearching(true);
     setErrorMessage(null);
     try {
-      const musicResults = await searchMusic(searchQuery);
+      const musicResults = await searchMusic(
+        searchQuery,
+        sort === 'popular' ? 'popular' : 'recent',
+      );
       setResults({
         tracks: musicResults.tracks || [],
         albums: musicResults.albums || [],
@@ -103,10 +134,17 @@ function SearchScreen() {
     >
       <Image source={{ uri: item.coverUrl }} style={styles.resultImage} />
       <View style={styles.resultInfo}>
-        <Text style={styles.resultTitle} numberOfLines={1}>{item.title}</Text>
-        <Text style={styles.resultSubtitle} numberOfLines={1}>{item.artist} • Song</Text>
+        <Text style={styles.resultTitle} numberOfLines={1}>
+          {item.title}
+        </Text>
+        <Text style={styles.resultSubtitle} numberOfLines={1}>
+          {item.artist} • Song
+        </Text>
       </View>
-      <TouchableOpacity style={styles.playButton} onPress={() => handleTrackPress(item)}>
+      <TouchableOpacity
+        style={styles.playButton}
+        onPress={() => handleTrackPress(item)}
+      >
         {currentTrack?.id === item.id && isPlaying ? (
           <Pause color="#8b5cf6" size={20} />
         ) : (
@@ -117,15 +155,26 @@ function SearchScreen() {
   );
 
   const renderUserItem = ({ item }: { item: any }) => (
-    <TouchableOpacity style={styles.resultItem} onPress={() => router.push(`/user/${item.id}`)}>
+    <TouchableOpacity
+      style={styles.resultItem}
+      onPress={() => router.push(`/user/${item.id}`)}
+    >
       <Image
-        source={{ uri: item.profile_picture_url || 'https://images.pexels.com/photos/771742/pexels-photo-771742.jpeg' }}
+        source={{
+          uri:
+            item.profile_picture_url ||
+            'https://images.pexels.com/photos/771742/pexels-photo-771742.jpeg',
+        }}
         style={[styles.resultImage, styles.userImage]}
       />
       <View style={styles.resultInfo}>
-        <Text style={styles.resultTitle} numberOfLines={1}>{item.display_name}</Text>
+        <Text style={styles.resultTitle} numberOfLines={1}>
+          {item.display_name}
+        </Text>
         <View style={styles.userMeta}>
-          <Text style={styles.resultSubtitle}>{item.follower_count} followers</Text>
+          <Text style={styles.resultSubtitle}>
+            {item.follower_count} followers
+          </Text>
           <View style={styles.privacyIndicator}>
             {item.is_private ? <Lock size={12} /> : <Globe size={12} />}
           </View>
@@ -141,17 +190,23 @@ function SearchScreen() {
     >
       <Image
         source={{
-          uri: item.avatar_url || 'https://images.pexels.com/photos/771742/pexels-photo-771742.jpeg',
+          uri:
+            item.avatar_url ||
+            'https://images.pexels.com/photos/771742/pexels-photo-771742.jpeg',
         }}
         style={styles.artistImage}
       />
-      <Text style={styles.artistName} numberOfLines={1}>{item.name}</Text>
+      <Text style={styles.artistName} numberOfLines={1}>
+        {item.name}
+      </Text>
     </TouchableOpacity>
   );
 
-
   return (
-    <LinearGradient colors={['#1a1a2e','#16213e','#0f3460']} style={styles.container}>
+    <LinearGradient
+      colors={['#1a1a2e', '#16213e', '#0f3460']}
+      style={styles.container}
+    >
       <View style={styles.header}>
         <Text style={styles.title}>Search</Text>
         <View style={styles.searchContainer}>
@@ -168,10 +223,15 @@ function SearchScreen() {
           {['relevance', 'recent', 'popular'].map((f) => (
             <TouchableOpacity
               key={f}
-              style={[styles.filterOption, sort === f && styles.filterOptionActive]}
+              style={[
+                styles.filterOption,
+                sort === f && styles.filterOptionActive,
+              ]}
               onPress={() => setSort(f as any)}
             >
-              <Text style={styles.filterText}>{f.charAt(0).toUpperCase() + f.slice(1)}</Text>
+              <Text style={styles.filterText}>
+                {f.charAt(0).toUpperCase() + f.slice(1)}
+              </Text>
             </TouchableOpacity>
           ))}
         </View>
@@ -265,39 +325,71 @@ function SearchScreen() {
 
 const styles = StyleSheet.create({
   container: { flex: 1 },
-  header: { padding:24, paddingTop:60, paddingBottom:16 },
-  title: { fontSize:28, fontFamily:'Poppins-Bold', color:'#fff' },
-  searchContainer: { flexDirection:'row', backgroundColor:'rgba(255,255,255,0.1)', borderRadius:12, padding:12, alignItems:'center' },
-  searchInput: { flex:1, marginLeft:8, color:'#fff' },
-  loadingContainer: { flex:1, justifyContent:'center', alignItems:'center' },
-  loadingText: { color:'#94a3b8', marginTop:12 },
-  errorContainer: { padding:24, alignItems:'center' },
-  errorText: { color:'#ef4444' },
-  content: { flex:1 },
-  section: { marginBottom:32, paddingHorizontal:24 },
-  sectionTitle: { fontSize:20, color:'#fff', marginBottom:16 },
-  trendingContainer: { flexDirection:'row', flexWrap:'wrap', marginBottom:16 },
-  trendingItem: { backgroundColor:'rgba(139,92,246,0.2)', padding:8, borderRadius:20, margin:4 },
-  trendingText: { color:'#8b5cf6' },
-  filterRow: { flexDirection:'row', gap:8, marginTop:12 },
-  filterOption: { paddingVertical:6, paddingHorizontal:12, borderRadius:20, backgroundColor:'rgba(255,255,255,0.05)' },
-  filterOptionActive: { backgroundColor:'rgba(139,92,246,0.3)' },
-  filterText: { color:'#fff', fontSize:12 },
-  resultItem: { flexDirection:'row', alignItems:'center', padding:12, marginHorizontal:24, marginBottom:8, backgroundColor:'rgba(255,255,255,0.05)', borderRadius:12 },
-  resultImage: { width:50, height:50, borderRadius:8 },
-  userImage: { borderRadius:25 },
-  resultInfo: { flex:1, marginLeft:12 },
-  resultTitle: { color:'#fff' },
-  resultSubtitle: { color:'#94a3b8' },
-  playButton: { padding:8 },
-  userMeta: { flexDirection:'row', alignItems:'center', justifyContent:'space-between' },
-  privacyIndicator: { marginLeft:8 },
-  emptyState: { alignItems:'center', marginTop:40 },
-  emptyText: { color:'#94a3b8' },
-  artistItem: { alignItems:'center', marginRight:16 },
-  artistImage: { width:80, height:80, borderRadius:40, marginBottom:8 },
-  artistName: { color:'#fff', maxWidth:80, textAlign:'center' },
-  bottomPadding: { height:120 }
+  header: { padding: 24, paddingTop: 60, paddingBottom: 16 },
+  title: { fontSize: 28, fontFamily: 'Poppins-Bold', color: '#fff' },
+  searchContainer: {
+    flexDirection: 'row',
+    backgroundColor: 'rgba(255,255,255,0.1)',
+    borderRadius: 12,
+    padding: 12,
+    alignItems: 'center',
+  },
+  searchInput: { flex: 1, marginLeft: 8, color: '#fff' },
+  loadingContainer: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+  loadingText: { color: '#94a3b8', marginTop: 12 },
+  errorContainer: { padding: 24, alignItems: 'center' },
+  errorText: { color: '#ef4444' },
+  content: { flex: 1 },
+  section: { marginBottom: 32, paddingHorizontal: 24 },
+  sectionTitle: { fontSize: 20, color: '#fff', marginBottom: 16 },
+  trendingContainer: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    marginBottom: 16,
+  },
+  trendingItem: {
+    backgroundColor: 'rgba(139,92,246,0.2)',
+    padding: 8,
+    borderRadius: 20,
+    margin: 4,
+  },
+  trendingText: { color: '#8b5cf6' },
+  filterRow: { flexDirection: 'row', gap: 8, marginTop: 12 },
+  filterOption: {
+    paddingVertical: 6,
+    paddingHorizontal: 12,
+    borderRadius: 20,
+    backgroundColor: 'rgba(255,255,255,0.05)',
+  },
+  filterOptionActive: { backgroundColor: 'rgba(139,92,246,0.3)' },
+  filterText: { color: '#fff', fontSize: 12 },
+  resultItem: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    padding: 12,
+    marginHorizontal: 24,
+    marginBottom: 8,
+    backgroundColor: 'rgba(255,255,255,0.05)',
+    borderRadius: 12,
+  },
+  resultImage: { width: 50, height: 50, borderRadius: 8 },
+  userImage: { borderRadius: 25 },
+  resultInfo: { flex: 1, marginLeft: 12 },
+  resultTitle: { color: '#fff' },
+  resultSubtitle: { color: '#94a3b8' },
+  playButton: { padding: 8 },
+  userMeta: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  privacyIndicator: { marginLeft: 8 },
+  emptyState: { alignItems: 'center', marginTop: 40 },
+  emptyText: { color: '#94a3b8' },
+  artistItem: { alignItems: 'center', marginRight: 16 },
+  artistImage: { width: 80, height: 80, borderRadius: 40, marginBottom: 8 },
+  artistName: { color: '#fff', maxWidth: 80, textAlign: 'center' },
+  bottomPadding: { height: 120 },
 });
 
 export default withAuthGuard(SearchScreen);

--- a/app/album/[id].tsx
+++ b/app/album/[id].tsx
@@ -51,20 +51,24 @@ function AlbumDetailScreen() {
       const albumData = await apiService.getAlbumById(id!);
       setAlbum(albumData);
 
-      const transformed = (albumData.tracks || []).map((t: any, idx: number) => ({
-        id: t.id,
-        title: t.title,
-        artist: albumData.artist || 'Unknown',
-        album: albumData.title,
-        duration: t.duration || 0,
-        coverUrl: albumData.cover_url,
-        audioUrl: t.audio_url,
-        isLiked: likedSongs.some(l => l.id === t.id),
-        trackNumber: t.track_number ?? idx + 1,
-        playCount: t.play_count,
-        likeCount: t.like_count,
-        lyrics: t.lyrics,
-      } as Track));
+      const transformed = (albumData.tracks || []).map(
+        (t: any, idx: number) =>
+          ({
+            id: t.id,
+            title: t.title,
+            artist: albumData.artist || 'Unknown',
+            artistId: t.artist_id || albumData.artist_id,
+            album: albumData.title,
+            duration: t.duration || 0,
+            coverUrl: apiService.getPublicUrl('cover-images', albumData.cover_url),
+            audioUrl: apiService.getPublicUrl('audio-files', t.audio_url),
+            isLiked: likedSongs.some((l) => l.id === t.id),
+            trackNumber: t.track_number ?? idx + 1,
+            playCount: t.play_count,
+            likeCount: t.like_count,
+            lyrics: t.lyrics,
+          }) as Track,
+      );
 
       // sort with explicit any types
       transformed.sort((a: any, b: any) => a.trackNumber - b.trackNumber);
@@ -88,7 +92,10 @@ function AlbumDetailScreen() {
 
   if (isLoading) {
     return (
-      <LinearGradient colors={['#1a1a2e','#16213e','#0f3460']} style={styles.container}>
+      <LinearGradient
+        colors={['#1a1a2e', '#16213e', '#0f3460']}
+        style={styles.container}
+      >
         <View style={styles.loadingContainer}>
           <ActivityIndicator size="large" color="#8b5cf6" />
           <Text style={styles.loadingText}>Loading album...</Text>
@@ -99,10 +106,16 @@ function AlbumDetailScreen() {
 
   if (error || !album) {
     return (
-      <LinearGradient colors={['#1a1a2e','#16213e','#0f3460']} style={styles.container}>
+      <LinearGradient
+        colors={['#1a1a2e', '#16213e', '#0f3460']}
+        style={styles.container}
+      >
         <View style={styles.errorContainer}>
           <Text style={styles.errorText}>{error || 'Album not found'}</Text>
-          <TouchableOpacity style={styles.backButton} onPress={() => router.back()}>
+          <TouchableOpacity
+            style={styles.backButton}
+            onPress={() => router.back()}
+          >
             <Text style={styles.backButtonText}>Go Back</Text>
           </TouchableOpacity>
         </View>
@@ -111,33 +124,66 @@ function AlbumDetailScreen() {
   }
 
   return (
-    <LinearGradient colors={['#1a1a2e','#16213e','#0f3460']} style={styles.container}>
+    <LinearGradient
+      colors={['#1a1a2e', '#16213e', '#0f3460']}
+      style={styles.container}
+    >
       <View style={styles.header}>
-        <TouchableOpacity onPress={() => router.back()} style={styles.headerButton}>
+        <TouchableOpacity
+          onPress={() => router.back()}
+          style={styles.headerButton}
+        >
           <ArrowLeft size={24} color="#fff" />
         </TouchableOpacity>
-        <TouchableOpacity onPress={() => {/* more options */}} style={styles.headerButton}>
+        <TouchableOpacity
+          onPress={() => {
+            /* more options */
+          }}
+          style={styles.headerButton}
+        >
           <MoreVertical size={24} color="#fff" />
         </TouchableOpacity>
       </View>
       <ScrollView style={styles.content} showsVerticalScrollIndicator={false}>
         {tracks.map((item) => (
-          <TouchableOpacity key={item.id} style={styles.trackItem} onPress={() => handleTrackPress(item)}>
+          <TouchableOpacity
+            key={item.id}
+            style={styles.trackItem}
+            onPress={() => handleTrackPress(item)}
+          >
             <View style={styles.trackNumber}>
               <Text style={styles.trackNumberText}>{item.trackNumber}</Text>
             </View>
             <View style={styles.trackInfo}>
-              <Text style={styles.trackTitle} numberOfLines={1}>{item.title}</Text>
+              <Text style={styles.trackTitle} numberOfLines={1}>
+                {item.title}
+              </Text>
               <View style={styles.trackMeta}>
-                <Text style={styles.trackDuration}>{Math.floor(item.duration/60)}:{(item.duration%60).toString().padStart(2,'0')}</Text>
-                {item.playCount != null && <Text style={styles.trackStats}>• {item.playCount}</Text>}
+                <Text style={styles.trackDuration}>
+                  {Math.floor(item.duration / 60)}:
+                  {(item.duration % 60).toString().padStart(2, '0')}
+                </Text>
+                {item.playCount != null && (
+                  <Text style={styles.trackStats}>• {item.playCount}</Text>
+                )}
               </View>
             </View>
-            <TouchableOpacity style={styles.likeButton} onPress={() => toggleLike(item.id)}>
-              <Heart color={item.isLiked ? '#ef4444':'#94a3b8'} size={20} fill={item.isLiked?'#ef4444':'transparent'} />
+            <TouchableOpacity
+              style={styles.likeButton}
+              onPress={() => toggleLike(item.id)}
+            >
+              <Heart
+                color={item.isLiked ? '#ef4444' : '#94a3b8'}
+                size={20}
+                fill={item.isLiked ? '#ef4444' : 'transparent'}
+              />
             </TouchableOpacity>
             <TouchableOpacity style={styles.playButton}>
-              {currentTrack?.id === item.id && isPlaying ? <Pause size={20} color="#8b5cf6"/> : <Play size={20} color="#8b5cf6"/>}
+              {currentTrack?.id === item.id && isPlaying ? (
+                <Pause size={20} color="#8b5cf6" />
+              ) : (
+                <Play size={20} color="#8b5cf6" />
+              )}
             </TouchableOpacity>
           </TouchableOpacity>
         ))}
@@ -151,22 +197,80 @@ export default withAuthGuard(AlbumDetailScreen);
 const styles = StyleSheet.create({
   container: { flex: 1 },
   loadingContainer: { flex: 1, justifyContent: 'center', alignItems: 'center' },
-  loadingText: { fontSize: 16, fontFamily: 'Inter-Regular', color: '#94a3b8', marginTop: 16 },
-  errorContainer: { flex: 1, justifyContent: 'center', alignItems: 'center', paddingHorizontal: 24 },
-  errorText: { fontSize: 18, fontFamily: 'Inter-SemiBold', color: '#ef4444', marginBottom: 24, textAlign: 'center' },
-  backButton: { backgroundColor: 'rgba(139,92,246,0.2)', padding: 12, borderRadius: 8, borderWidth: 1, borderColor: 'rgba(139,92,246,0.3)' },
-  backButtonText: { color: '#8b5cf6', fontSize: 16, fontFamily: 'Inter-SemiBold' },
-  header: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', padding: 20, paddingTop: 60 },
-  headerButton: { width: 44, height: 44, justifyContent: 'center', alignItems: 'center' },
+  loadingText: {
+    fontSize: 16,
+    fontFamily: 'Inter-Regular',
+    color: '#94a3b8',
+    marginTop: 16,
+  },
+  errorContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    paddingHorizontal: 24,
+  },
+  errorText: {
+    fontSize: 18,
+    fontFamily: 'Inter-SemiBold',
+    color: '#ef4444',
+    marginBottom: 24,
+    textAlign: 'center',
+  },
+  backButton: {
+    backgroundColor: 'rgba(139,92,246,0.2)',
+    padding: 12,
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: 'rgba(139,92,246,0.3)',
+  },
+  backButtonText: {
+    color: '#8b5cf6',
+    fontSize: 16,
+    fontFamily: 'Inter-SemiBold',
+  },
+  header: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    padding: 20,
+    paddingTop: 60,
+  },
+  headerButton: {
+    width: 44,
+    height: 44,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
   content: { flex: 1 },
-  trackItem: { flexDirection: 'row', alignItems: 'center', padding: 12, backgroundColor: 'rgba(255,255,255,0.05)', marginHorizontal: 20, marginBottom: 8, borderRadius: 8 },
+  trackItem: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    padding: 12,
+    backgroundColor: 'rgba(255,255,255,0.05)',
+    marginHorizontal: 20,
+    marginBottom: 8,
+    borderRadius: 8,
+  },
   trackNumber: { width: 24, alignItems: 'center' },
-  trackNumberText: { fontSize: 14, fontFamily: 'Inter-Regular', color: '#94a3b8' },
+  trackNumberText: {
+    fontSize: 14,
+    fontFamily: 'Inter-Regular',
+    color: '#94a3b8',
+  },
   trackInfo: { flex: 1, marginLeft: 12 },
   trackTitle: { fontSize: 16, fontFamily: 'Inter-SemiBold', color: '#ffffff' },
   trackMeta: { flexDirection: 'row', alignItems: 'center', marginTop: 4 },
-  trackDuration: { fontSize: 12, fontFamily: 'Inter-Regular', color: '#94a3b8' },
-  trackStats: { fontSize: 12, fontFamily: 'Inter-Regular', color: '#94a3b8', marginLeft: 4 },
+  trackDuration: {
+    fontSize: 12,
+    fontFamily: 'Inter-Regular',
+    color: '#94a3b8',
+  },
+  trackStats: {
+    fontSize: 12,
+    fontFamily: 'Inter-Regular',
+    color: '#94a3b8',
+    marginLeft: 4,
+  },
   likeButton: { padding: 8 },
   playButton: { padding: 8 },
 });

--- a/app/track/[id].tsx
+++ b/app/track/[id].tsx
@@ -12,7 +12,7 @@ import {
 } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
 import { useLocalSearchParams, useRouter } from 'expo-router';
-import { useMusic } from '@/providers/MusicProvider';
+import { useMusic, Track } from '@/providers/MusicProvider';
 import { apiService } from '@/services/api';
 import {
   ArrowLeft,
@@ -28,23 +28,6 @@ import {
 } from 'lucide-react-native';
 
 export default function TrackDetailScreen() {
-  interface Track {
-    id: string;
-    title: string;
-    artist: string;
-    album: string;
-    duration: number;
-    coverUrl: string;
-    audioUrl: string;
-    isLiked: boolean;
-    genre: string;
-    releaseDate: string;
-    playCount?: number;
-    likeCount?: number;
-    lyrics?: string;
-    description?: string;
-    genres?: string[];
-  }
 
   const router = useRouter();
   const { id } = useLocalSearchParams();
@@ -60,7 +43,7 @@ export default function TrackDetailScreen() {
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  const { currentTrack, isPlaying, playTrack, pauseTrack } = useMusic();
+  const { currentTrack, isPlaying, playTrack, pauseTrack, toggleLike, likedSongs } = useMusic();
 
   useEffect(() => {
     if (id) loadTrackDetails();
@@ -80,20 +63,23 @@ export default function TrackDetailScreen() {
           singleData.artist_name ||
           singleData.artist ||
           'Unknown Artist',
+        artistId: singleData.artist_id,
         album: singleData.album?.title || singleData.album || 'Single',
         duration: singleData.duration || 180,
         coverUrl:
-          singleData.cover_url ||
-          singleData.album?.cover_url ||
-          'https://images.pexels.com/photos/167092/pexels-photo-167092.jpeg?auto=compress&cs=tinysrgb&w=400',
-        audioUrl: singleData.audio_url || '',
-        isLiked: false,
-        genre:
-          Array.isArray(singleData.genres)
-            ? singleData.genres[0]
-            : singleData.genre || 'Unknown',
+          apiService.getPublicUrl(
+            'cover-images',
+            singleData.cover_url || singleData.album?.cover_url || '',
+          ),
+        audioUrl: apiService.getPublicUrl('audio-files', singleData.audio_url),
+        isLiked: likedSongs.some((l) => l.id === singleData.id),
+        genre: Array.isArray(singleData.genres)
+          ? singleData.genres[0]
+          : singleData.genre || 'Unknown',
         releaseDate:
-          singleData.release_date || singleData.created_at || new Date().toISOString(),
+          singleData.release_date ||
+          singleData.created_at ||
+          new Date().toISOString(),
         playCount: singleData.play_count,
         likeCount: singleData.like_count,
         lyrics: singleData.lyrics,
@@ -122,9 +108,8 @@ export default function TrackDetailScreen() {
 
   const handleLike = () => {
     if (!track) return;
-    setTrack(prev =>
-      prev ? { ...prev, isLiked: !prev.isLiked } : prev
-    );
+    toggleLike(track.id);
+    setTrack((prev) => (prev ? { ...prev, isLiked: !prev.isLiked } : prev));
   };
 
   const handleAddToQueue = () => {
@@ -179,7 +164,10 @@ export default function TrackDetailScreen() {
       >
         <View style={styles.errorContainer}>
           <Text style={styles.errorText}>{error || 'Track not found'}</Text>
-          <TouchableOpacity style={styles.backButton} onPress={() => router.back()}>
+          <TouchableOpacity
+            style={styles.backButton}
+            onPress={() => router.back()}
+          >
             <Text style={styles.backButtonText}>Go Back</Text>
           </TouchableOpacity>
         </View>
@@ -193,7 +181,10 @@ export default function TrackDetailScreen() {
       style={styles.container}
     >
       <View style={styles.header}>
-        <TouchableOpacity style={styles.headerButton} onPress={() => router.back()}>
+        <TouchableOpacity
+          style={styles.headerButton}
+          onPress={() => router.back()}
+        >
           <ArrowLeft color="#ffffff" size={24} />
         </TouchableOpacity>
         <TouchableOpacity style={styles.headerButton}>
@@ -212,16 +203,22 @@ export default function TrackDetailScreen() {
           <View style={styles.trackMeta}>
             <View style={styles.metaItem}>
               <Calendar color="#94a3b8" size={16} />
-              <Text style={styles.metaText}>{formatDate(track.releaseDate)}</Text>
+              <Text style={styles.metaText}>
+                {formatDate(track.releaseDate)}
+              </Text>
             </View>
             <View style={styles.metaItem}>
               <Clock color="#94a3b8" size={16} />
-              <Text style={styles.metaText}>{formatDuration(track.duration)}</Text>
+              <Text style={styles.metaText}>
+                {formatDuration(track.duration)}
+              </Text>
             </View>
             {track.playCount && (
               <View style={styles.metaItem}>
                 <Music color="#94a3b8" size={16} />
-                <Text style={styles.metaText}>{track.playCount.toLocaleString()} plays</Text>
+                <Text style={styles.metaText}>
+                  {track.playCount.toLocaleString()} plays
+                </Text>
               </View>
             )}
           </View>
@@ -238,10 +235,17 @@ export default function TrackDetailScreen() {
 
         <View style={styles.controlsSection}>
           <TouchableOpacity style={styles.actionButton} onPress={handleLike}>
-            <Heart color={track.isLiked ? '#ef4444' : '#ffffff'} size={24} fill={track.isLiked ? '#ef4444' : 'transparent'} />
+            <Heart
+              color={track.isLiked ? '#ef4444' : '#ffffff'}
+              size={24}
+              fill={track.isLiked ? '#ef4444' : 'transparent'}
+            />
           </TouchableOpacity>
           <TouchableOpacity style={styles.playButton} onPress={handlePlayPause}>
-            <LinearGradient colors={['#8b5cf6', '#a855f7']} style={styles.playButtonGradient}>
+            <LinearGradient
+              colors={['#8b5cf6', '#a855f7']}
+              style={styles.playButtonGradient}
+            >
               {currentTrack?.id === track.id && isPlaying ? (
                 <Pause color="#ffffff" size={32} />
               ) : (
@@ -249,7 +253,10 @@ export default function TrackDetailScreen() {
               )}
             </LinearGradient>
           </TouchableOpacity>
-          <TouchableOpacity style={styles.actionButton} onPress={handleAddToQueue}>
+          <TouchableOpacity
+            style={styles.actionButton}
+            onPress={handleAddToQueue}
+          >
             <Plus color="#ffffff" size={24} />
           </TouchableOpacity>
           <TouchableOpacity style={styles.actionButton} onPress={handleShare}>
@@ -280,34 +287,169 @@ export default function TrackDetailScreen() {
 const styles = StyleSheet.create({
   container: { flex: 1 },
   loadingContainer: { flex: 1, justifyContent: 'center', alignItems: 'center' },
-  loadingText: { fontSize: 16, fontFamily: 'Inter-Regular', color: '#94a3b8', marginTop: 16 },
-  errorContainer: { flex: 1, justifyContent: 'center', alignItems: 'center', paddingHorizontal: 24 },
-  errorText: { fontSize: 18, fontFamily: 'Inter-SemiBold', color: '#ef4444', textAlign: 'center', marginBottom: 24 },
-  backButton: { backgroundColor: 'rgba(139, 92, 246, 0.2)', paddingHorizontal: 24, paddingVertical: 12, borderRadius: 8, borderWidth: 1, borderColor: 'rgba(139, 92, 246, 0.3)' },
-  backButtonText: { color: '#8b5cf6', fontSize: 16, fontFamily: 'Inter-SemiBold' },
-  header: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', paddingHorizontal: 20, paddingTop: 60, paddingBottom: 20 },
-  headerButton: { width: 44, height: 44, justifyContent: 'center', alignItems: 'center' },
+  loadingText: {
+    fontSize: 16,
+    fontFamily: 'Inter-Regular',
+    color: '#94a3b8',
+    marginTop: 16,
+  },
+  errorContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    paddingHorizontal: 24,
+  },
+  errorText: {
+    fontSize: 18,
+    fontFamily: 'Inter-SemiBold',
+    color: '#ef4444',
+    textAlign: 'center',
+    marginBottom: 24,
+  },
+  backButton: {
+    backgroundColor: 'rgba(139, 92, 246, 0.2)',
+    paddingHorizontal: 24,
+    paddingVertical: 12,
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: 'rgba(139, 92, 246, 0.3)',
+  },
+  backButtonText: {
+    color: '#8b5cf6',
+    fontSize: 16,
+    fontFamily: 'Inter-SemiBold',
+  },
+  header: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingHorizontal: 20,
+    paddingTop: 60,
+    paddingBottom: 20,
+  },
+  headerButton: {
+    width: 44,
+    height: 44,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
   content: { flex: 1 },
-  trackHeader: { alignItems: 'center', paddingHorizontal: 24, marginBottom: 32 },
-  trackCover: { width: 280, height: 280, borderRadius: 16, marginBottom: 24, shadowColor: '#000', shadowOffset: { width: 0, height: 8 }, shadowOpacity: 0.3, shadowRadius: 16 },
-  trackTitle: { fontSize: 28, fontFamily: 'Poppins-Bold', color: '#ffffff', textAlign: 'center', marginBottom: 8 },
-  trackArtist: { fontSize: 20, fontFamily: 'Inter-SemiBold', color: '#a855f7', textAlign: 'center', marginBottom: 12 },
-  trackDescription: { fontSize: 16, fontFamily: 'Inter-Regular', color: '#cbd5e1', textAlign: 'center', lineHeight: 24, marginBottom: 20 },
-  trackMeta: { flexDirection: 'row', justifyContent: 'center', flexWrap: 'wrap', gap: 16, marginBottom: 20 },
+  trackHeader: {
+    alignItems: 'center',
+    paddingHorizontal: 24,
+    marginBottom: 32,
+  },
+  trackCover: {
+    width: 280,
+    height: 280,
+    borderRadius: 16,
+    marginBottom: 24,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 8 },
+    shadowOpacity: 0.3,
+    shadowRadius: 16,
+  },
+  trackTitle: {
+    fontSize: 28,
+    fontFamily: 'Poppins-Bold',
+    color: '#ffffff',
+    textAlign: 'center',
+    marginBottom: 8,
+  },
+  trackArtist: {
+    fontSize: 20,
+    fontFamily: 'Inter-SemiBold',
+    color: '#a855f7',
+    textAlign: 'center',
+    marginBottom: 12,
+  },
+  trackDescription: {
+    fontSize: 16,
+    fontFamily: 'Inter-Regular',
+    color: '#cbd5e1',
+    textAlign: 'center',
+    lineHeight: 24,
+    marginBottom: 20,
+  },
+  trackMeta: {
+    flexDirection: 'row',
+    justifyContent: 'center',
+    flexWrap: 'wrap',
+    gap: 16,
+    marginBottom: 20,
+  },
   metaItem: { flexDirection: 'row', alignItems: 'center', gap: 6 },
   metaText: { fontSize: 14, fontFamily: 'Inter-Regular', color: '#94a3b8' },
-  genresContainer: { flexDirection: 'row', flexWrap: 'wrap', justifyContent: 'center', gap: 8 },
-  genreTag: { backgroundColor: 'rgba(139, 92, 246, 0.2)', paddingHorizontal: 12, paddingVertical: 6, borderRadius: 16, borderWidth: 1, borderColor: 'rgba(139, 92, 246, 0.3)' },
+  genresContainer: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    justifyContent: 'center',
+    gap: 8,
+  },
+  genreTag: {
+    backgroundColor: 'rgba(139, 92, 246, 0.2)',
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 16,
+    borderWidth: 1,
+    borderColor: 'rgba(139, 92, 246, 0.3)',
+  },
   genreText: { fontSize: 12, fontFamily: 'Inter-Medium', color: '#8b5cf6' },
-  controlsSection: { flexDirection: 'row', justifyContent: 'center', alignItems: 'center', paddingHorizontal: 24, marginBottom: 32, gap: 16 },
-  actionButton: { width: 50, height: 50, borderRadius: 25, backgroundColor: 'rgba(255, 255, 255, 0.1)', justifyContent: 'center', alignItems: 'center' },
-  playButton: { width: 80, height: 80, borderRadius: 40, overflow: 'hidden', elevation: 8, shadowColor: '#8b5cf6', shadowOffset: { width: 0, height: 4 }, shadowOpacity: 0.4, shadowRadius: 12, marginHorizontal: 16 },
-  playButtonGradient: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+  controlsSection: {
+    flexDirection: 'row',
+    justifyContent: 'center',
+    alignItems: 'center',
+    paddingHorizontal: 24,
+    marginBottom: 32,
+    gap: 16,
+  },
+  actionButton: {
+    width: 50,
+    height: 50,
+    borderRadius: 25,
+    backgroundColor: 'rgba(255, 255, 255, 0.1)',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  playButton: {
+    width: 80,
+    height: 80,
+    borderRadius: 40,
+    overflow: 'hidden',
+    elevation: 8,
+    shadowColor: '#8b5cf6',
+    shadowOffset: { width: 0, height: 4 },
+    shadowOpacity: 0.4,
+    shadowRadius: 12,
+    marginHorizontal: 16,
+  },
+  playButtonGradient: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
   actionsSection: { paddingHorizontal: 24, marginBottom: 32 },
-  actionRow: { flexDirection: 'row', alignItems: 'center', backgroundColor: 'rgba(255, 255, 255, 0.05)', borderRadius: 12, padding: 16, gap: 12 },
+  actionRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: 'rgba(255, 255, 255, 0.05)',
+    borderRadius: 12,
+    padding: 16,
+    gap: 12,
+  },
   actionText: { fontSize: 16, fontFamily: 'Inter-SemiBold', color: '#ffffff' },
   lyricsSection: { paddingHorizontal: 24, marginBottom: 32 },
-  lyricsTitle: { fontSize: 20, fontFamily: 'Poppins-SemiBold', color: '#ffffff', marginBottom: 16 },
-  lyricsText: { fontSize: 16, fontFamily: 'Inter-Regular', color: '#cbd5e1', lineHeight: 24 },
+  lyricsTitle: {
+    fontSize: 20,
+    fontFamily: 'Poppins-SemiBold',
+    color: '#ffffff',
+    marginBottom: 16,
+  },
+  lyricsText: {
+    fontSize: 16,
+    fontFamily: 'Inter-Regular',
+    color: '#cbd5e1',
+    lineHeight: 24,
+  },
   bottomPadding: { height: 120 },
 });


### PR DESCRIPTION
## Summary
- use Supabase storage URLs when loading album, track and single data
- expose helper methods in api service and record song plays
- update music provider search and playback logic for Supabase
- fetch and display top songs and playlists on profile screen
- sync library page with playlist param and allow removing liked songs

## Testing
- `npm run lint` *(fails: 94 errors)*

------
https://chatgpt.com/codex/tasks/task_e_688b607726a08324af7a362a815abac9