### PR TITLE
fix: import apiService where used

### DIFF
--- a/app/(tabs)/search.tsx
+++ b/app/(tabs)/search.tsx
@@ -23,6 +23,7 @@ import {
   Heart,
 } from 'lucide-react-native';
 import { withAuthGuard } from '@/hoc/withAuthGuard';
+import { apiService } from '@/services/api';
 
 interface SearchResults {
   tracks: any[];

--- a/providers/AuthProvider.tsx
+++ b/providers/AuthProvider.tsx
@@ -7,8 +7,8 @@ import React, {
   useRef,
 } from 'react';
 import { Session } from '@supabase/supabase-js';
-import { apiService } from '../services/api';
-import { supabase } from '../services/supabase';
+import { apiService } from '@/services/api';
+import { supabase } from '@/services/supabase';
 
 type Profile = {
   id: string;


### PR DESCRIPTION
## Summary
- import apiService into search screen to resolve ReferenceError when fetching tracks
- use project alias for apiService and supabase in AuthProvider for consistency

## Testing
- `npm run lint` *(fails: React must be in scope, @typescript-eslint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6890045daec08324b57402f291b523a8