### PR TITLE
refactor: clean schema and types

### DIFF
--- a/app/(tabs)/library.tsx
+++ b/app/(tabs)/library.tsx
@@ -14,7 +14,15 @@ import { LinearGradient } from 'expo-linear-gradient';
 import { useMusic, Track, Playlist } from '@/providers/MusicProvider';
 import { supabase } from '@/services/supabase';
 import { apiService } from '@/services/api';
-import { Heart, Music, Plus, Play, Pause, MoveVertical as MoreVertical, X } from 'lucide-react-native';
+import {
+  Heart,
+  Music,
+  Plus,
+  Play,
+  Pause,
+  MoveVertical as MoreVertical,
+  X,
+} from 'lucide-react-native';
 import { withAuthGuard } from '@/hoc/withAuthGuard';
 import { useLocalSearchParams } from 'expo-router';
 
@@ -53,7 +61,7 @@ function LibraryScreen() {
     const uid = authData.user?.id;
     if (!uid) return;
 
-  const { data } = await supabase
+    const { data } = await supabase
       .from('favorites')
       .select('album:album_id(*, artist:artist_id(*))')
       .eq('user_id', uid)
@@ -74,10 +82,7 @@ function LibraryScreen() {
       title: r.album.title,
       artist: r.album.artist?.name || '',
       year: r.album.release_year || '',
-      coverUrl: apiService.getPublicUrl(
-        'images',
-        r.album.cover_url || '',
-      ),
+      coverUrl: apiService.getPublicUrl('images', r.album.cover_url || ''),
     }));
     setSavedAlbums(mapped);
   }
@@ -96,7 +101,11 @@ function LibraryScreen() {
 
   const handleTrackPress = (track: Track) => {
     if (currentTrack?.id === track.id) {
-      isPlaying ? pauseTrack() : playTrack(track, likedSongs);
+      if (isPlaying) {
+        pauseTrack();
+      } else {
+        playTrack(track, likedSongs);
+      }
     } else {
       playTrack(track, likedSongs);
     }
@@ -132,7 +141,7 @@ function LibraryScreen() {
       <Image source={{ uri: item.coverUrl }} style={styles.playlistCover} />
       <View style={styles.playlistInfo}>
         <Text style={styles.playlistTitle} numberOfLines={1}>
-          {item.name}
+          {item.title}
         </Text>
         <Text style={styles.playlistDescription} numberOfLines={1}>
           {item.tracks.length} songs

--- a/app/+not-found.tsx
+++ b/app/+not-found.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { Link, Stack } from 'expo-router';
 import { StyleSheet, Text, View } from 'react-native';
 
@@ -6,7 +7,7 @@ export default function NotFoundScreen() {
     <>
       <Stack.Screen options={{ title: 'Oops!' }} />
       <View style={styles.container}>
-        <Text style={styles.text}>This screen doesn't exist.</Text>
+        <Text style={styles.text}>This screen doesn&apos;t exist.</Text>
         <Link href="/" style={styles.link}>
           <Text>Go to home screen!</Text>
         </Link>

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import React from 'react';
 import { Stack } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 import { useFrameworkReady } from '@/hooks/useFrameworkReady';
@@ -16,11 +16,14 @@ export default function RootLayout() {
           <Stack screenOptions={{ headerShown: false }}>
             <Stack.Screen name="(auth)" options={{ headerShown: false }} />
             <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
-            <Stack.Screen name="player" options={{ 
-              headerShown: false,
-              presentation: 'modal',
-              animation: 'slide_from_bottom'
-            }} />
+            <Stack.Screen
+              name="player"
+              options={{
+                headerShown: false,
+                presentation: 'modal',
+                animation: 'slide_from_bottom',
+              }}
+            />
             <Stack.Screen name="+not-found" />
           </Stack>
           <StatusBar style="light" />

--- a/app/track/[id].tsx
+++ b/app/track/[id].tsx
@@ -29,7 +29,6 @@ import {
 } from 'lucide-react-native';
 
 export default function TrackDetailScreen() {
-
   const router = useRouter();
   const { id } = useLocalSearchParams();
   if (!id || typeof id !== 'string') {
@@ -44,7 +43,14 @@ export default function TrackDetailScreen() {
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  const { currentTrack, isPlaying, playTrack, pauseTrack, toggleLike, likedSongs } = useMusic();
+  const {
+    currentTrack,
+    isPlaying,
+    playTrack,
+    pauseTrack,
+    toggleLike,
+    likedSongs,
+  } = useMusic();
 
   useEffect(() => {
     if (id) loadTrackDetails();
@@ -64,7 +70,11 @@ export default function TrackDetailScreen() {
       if (error || !data) throw error;
 
       // If this track isn't part of an album, check if it's registered as a single
-      let singleExtra: any = null;
+      let singleExtra: {
+        release_date?: string;
+        lyrics?: string;
+        description?: string;
+      } | null = null;
       if (!data.album_id) {
         const { data: s } = await supabase
           .from('singles')
@@ -91,9 +101,18 @@ export default function TrackDetailScreen() {
         ),
         audioUrl: apiService.getPublicUrl('audio-files', data.audio_url),
         isLiked: likedSongs.some((l) => l.id === data.id),
-        genre: Array.isArray(data.genres) ? data.genres[0] : data.genre || 'Unknown',
+        genre: Array.isArray(data.genres)
+          ? data.genres[0]
+          : data.genre || 'Unknown',
         releaseDate:
           data.release_date || singleExtra?.release_date || data.created_at,
+        year: (data.release_date || singleExtra?.release_date)
+          ? new Date(
+              data.release_date || singleExtra?.release_date || data.created_at,
+            )
+              .getFullYear()
+              .toString()
+          : undefined,
         playCount: data.play_count,
         likeCount: data.like_count,
         lyrics: data.lyrics || singleExtra?.lyrics || '',

--- a/providers/AuthProvider.tsx
+++ b/providers/AuthProvider.tsx
@@ -19,7 +19,7 @@ type Profile = {
   bio?: string;
   avatar_url?: string;
   is_private?: boolean;
-  [key: string]: any;
+  [key: string]: unknown;
 };
 
 type AuthContextType = {
@@ -175,7 +175,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
           firstName,
           lastName,
           isPrivate,
-        } = additionalData as any;
+        } = additionalData as Partial<Profile>;
 
         const { data, error } = await supabase.auth.signUp({
           email,

--- a/supabase/migrations/20250629090000_fix_foreign_keys.sql
+++ b/supabase/migrations/20250629090000_fix_foreign_keys.sql
@@ -1,0 +1,22 @@
+-- Remove redundant foreign keys and add missing ones
+-- Ensure each relationship has a single well-named constraint
+
+-- Drop duplicate foreign keys on liked_songs
+ALTER TABLE liked_songs DROP CONSTRAINT IF EXISTS liked_songs_track_id_fkey1;
+ALTER TABLE liked_songs DROP CONSTRAINT IF EXISTS liked_songs_track_id_fkey2;
+ALTER TABLE liked_songs DROP CONSTRAINT IF EXISTS liked_songs_track_id_fkey;
+ALTER TABLE liked_songs ADD CONSTRAINT fk_liked_songs_track FOREIGN KEY (track_id) REFERENCES tracks(id) ON DELETE CASCADE;
+
+-- Drop duplicate foreign keys on playlist_tracks
+ALTER TABLE playlist_tracks DROP CONSTRAINT IF EXISTS playlist_tracks_track_id_fkey1;
+ALTER TABLE playlist_tracks DROP CONSTRAINT IF EXISTS playlist_tracks_track_id_fkey;
+ALTER TABLE playlist_tracks ADD CONSTRAINT fk_playlist_tracks_track FOREIGN KEY (track_id) REFERENCES tracks(id) ON DELETE CASCADE;
+
+ALTER TABLE playlist_tracks DROP CONSTRAINT IF EXISTS playlist_tracks_playlist_id_fkey1;
+ALTER TABLE playlist_tracks DROP CONSTRAINT IF EXISTS playlist_tracks_playlist_id_fkey;
+ALTER TABLE playlist_tracks ADD CONSTRAINT fk_playlist_tracks_playlist FOREIGN KEY (playlist_id) REFERENCES playlists(id) ON DELETE CASCADE;
+
+-- Ensure albums reference artists
+ALTER TABLE albums ADD COLUMN IF NOT EXISTS artist_id uuid;
+ALTER TABLE albums DROP CONSTRAINT IF EXISTS albums_artist_id_fkey;
+ALTER TABLE albums ADD CONSTRAINT fk_albums_artist FOREIGN KEY (artist_id) REFERENCES artists(id) ON DELETE SET NULL;


### PR DESCRIPTION
## Summary
- drop redundant foreign keys and ensure albums reference artists
- align playlist field names and map joined data with explicit foreign keys
- expand track typing and remove remaining `any` uses across API and UI

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6890cd1004708324afdbf8626105d44c