### PR TITLE
fix: resolve lint warnings

### DIFF
--- a/providers/FontProvider.tsx
+++ b/providers/FontProvider.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useEffect, useState } from 'react';
+import React, { createContext, useContext, useEffect } from 'react';
 import { useFonts } from 'expo-font';
 import {
   Inter_400Regular,
@@ -51,4 +51,4 @@ export function FontProvider({ children }: { children: React.ReactNode }) {
   );
 }
 
-const useFontContext = () => useContext(FontContext);
+export const useFontContext = () => useContext(FontContext);

--- a/providers/MusicProvider.tsx
+++ b/providers/MusicProvider.tsx
@@ -159,7 +159,7 @@ export function MusicProvider({ children }: { children: React.ReactNode }) {
   // Library-related state
   const [likedSongs, setLikedSongs] = useState<Track[]>([]);
   const [playlists, setPlaylists] = useState<Playlist[]>([]);
-  const [albums, setAlbums] = useState<Track[]>([]);
+  const [albums] = useState<Track[]>([]);
 
   const mapTrack = (t: TrackRow, liked = false): Track => ({
     id: t.id,
@@ -544,7 +544,7 @@ export function MusicProvider({ children }: { children: React.ReactNode }) {
           .from('tracks')
           .select(`*, artist:artist_id(*), album:album_id(*)`)
           .or(
-            `title.ilike.%${term}%,artist.name.ilike.%${term}%,genres.cs.{\"${term}\"}`,
+            `title.ilike.%${term}%,artist.name.ilike.%${term}%,genres.cs.{"${term}"}`,
           )
           .eq('is_published', true)
           .order(sort === 'popular' ? 'play_count' : 'created_at', {


### PR DESCRIPTION
## Summary
- tidy FontProvider by removing unused hook and exporting font context
- clean up MusicProvider lint issues and simplify genre search string

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6891e3ab4cf08324af15e6a4caf10b68