### PR TITLE
style: allow navigation overlay

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -41,11 +41,12 @@ export default function RootLayout() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    flexDirection: 'row',              // nav + content side by side
-    backgroundColor: '#0f172a',        // match your theme
+    position: 'relative',     // enable absolute children
+    overflow: 'visible',      // don't clip them
+    backgroundColor: '#0f172a',
   },
   content: {
     flex: 1,
-    paddingBottom: Platform.OS === 'web' ? 0 : 80, // give room for MiniPlayer on native
+    paddingBottom: Platform.OS === 'web' ? 0 : 96,
   },
 });

--- a/components/Navigation.tsx
+++ b/components/Navigation.tsx
@@ -52,20 +52,23 @@ const styles = StyleSheet.create({
   container: {
     ...Platform.select({
       web: {
+        position: 'fixed',
+        bottom: 16,
+        left: 16,
         width: 256,
-        paddingTop: 24,
-        flexDirection: 'column',
+        zIndex: 1000,
       },
       default: {
         position: 'absolute',
         bottom: 16,
         left: 16,
         right: 16,
-        flexDirection: 'row',
-        justifyContent: 'space-around',
-        paddingVertical: 8,
+        zIndex: 1000,
       },
     }),
+    flexDirection: Platform.OS === 'web' ? 'column' : 'row',
+    justifyContent: 'space-around',
+    paddingVertical: 8,
   },
 
   // Neobrutalist card styles


### PR DESCRIPTION
## Summary
- allow absolutely-positioned elements by making the tab layout container relative with visible overflow
- keep navigation bar above content using absolute/fixed positioning and high z-index

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6891edb133bc8324afef4c26f194f352