### PR TITLE
Fix missing user stats and icons on home tab

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -10,7 +10,8 @@ import {
 import { LinearGradient } from 'expo-linear-gradient';
 import { withAuthGuard } from '@/hoc/withAuthGuard';
 import { useMusic, Track } from '@/providers/MusicProvider';
-import { Play, TrendingUp, Clock, Star } from 'lucide-react-native';
+import { useUserStats } from '@/hooks/useUserStats';
+import { Play, TrendingUp, Clock, Star, User, Music } from 'lucide-react-native';
 import Animated, { FadeInDown, FadeIn } from 'react-native-reanimated';
 
 const featuredPlaylists = [
@@ -65,6 +66,7 @@ const mockTrending: Track[] = [
 
 function HomeScreen() {
   const { playTrack, trendingTracks } = useMusic();
+  const { stats } = useUserStats();
 
   const tracks = trendingTracks.length > 0 ? trendingTracks : mockTrending;
 


### PR DESCRIPTION
## Summary
- load user stats on home screen
- import missing User and Music icons

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npx tsc -p tsconfig.json --noEmit` *(fails: `components/Navigation.tsx` position type error)*


------
https://chatgpt.com/codex/tasks/task_e_6891f41d7abc83248a228c0325674183