### PR TITLE
Add library modal and realtime stats updates

### DIFF
--- a/components/TrackMenu.tsx
+++ b/components/TrackMenu.tsx
@@ -12,15 +12,12 @@ import { useMusic, Track, Playlist } from '@/providers/MusicProvider';
 
 interface Props {
   track: Track;
+  playlistId?: string;
 }
 
-export default function TrackMenu({ track }: Props) {
-  const {
-    toggleLike,
-    addToQueue,
-    playlists,
-    addToPlaylist,
-  } = useMusic();
+export default function TrackMenu({ track, playlistId }: Props) {
+  const { toggleLike, addToQueue, playlists, addToPlaylist, removeFromPlaylist } =
+    useMusic();
   const [visible, setVisible] = useState(false);
   const [selectPlaylist, setSelectPlaylist] = useState(false);
 
@@ -37,8 +34,18 @@ export default function TrackMenu({ track }: Props) {
       </TouchableOpacity>
       <Modal transparent visible={visible} animationType="fade">
         <View style={styles.overlay}>
-          <View style={[styles.menu, styles.glassCard, styles.brutalBorder, styles.brutalShadow]}>
-            <TouchableOpacity style={styles.close} onPress={() => setVisible(false)}>
+          <View
+            style={[
+              styles.menu,
+              styles.glassCard,
+              styles.brutalBorder,
+              styles.brutalShadow,
+            ]}
+          >
+            <TouchableOpacity
+              style={styles.close}
+              onPress={() => setVisible(false)}
+            >
               <X color="#fff" size={20} />
             </TouchableOpacity>
             <TouchableOpacity
@@ -47,6 +54,17 @@ export default function TrackMenu({ track }: Props) {
             >
               <Text style={styles.menuText}>Add to Playlist</Text>
             </TouchableOpacity>
+            {playlistId && (
+              <TouchableOpacity
+                style={styles.menuItem}
+                onPress={() => {
+                  removeFromPlaylist(playlistId, track.id);
+                  setVisible(false);
+                }}
+              >
+                <Text style={styles.menuText}>Remove from Playlist</Text>
+              </TouchableOpacity>
+            )}
             <TouchableOpacity
               style={styles.menuItem}
               onPress={() => {
@@ -72,7 +90,14 @@ export default function TrackMenu({ track }: Props) {
       </Modal>
       <Modal transparent visible={selectPlaylist} animationType="fade">
         <View style={styles.overlay}>
-          <View style={[styles.playlistSelect, styles.glassCard, styles.brutalBorder, styles.brutalShadow]}>
+          <View
+            style={[
+              styles.playlistSelect,
+              styles.glassCard,
+              styles.brutalBorder,
+              styles.brutalShadow,
+            ]}
+          >
             <TouchableOpacity
               style={styles.close}
               onPress={() => setSelectPlaylist(false)}

--- a/hooks/useUserStats.ts
+++ b/hooks/useUserStats.ts
@@ -1,6 +1,7 @@
-import { useEffect, useState } from 'react';
-import { fetchUserStats } from '@/services/stats'; // we'll define this next
+import { useEffect, useState, useCallback } from 'react';
+import { fetchUserStats } from '@/services/stats';
 import { useAuth } from '@/providers/AuthProvider';
+import { supabase } from '@/services/supabase';
 
 export function useUserStats() {
   const { user } = useAuth();
@@ -12,18 +13,43 @@ export function useUserStats() {
   });
   const [loading, setLoading] = useState(true);
 
+  const loadStats = useCallback(async () => {
+    if (!user?.id) return;
+    setLoading(true);
+    const userStats = await fetchUserStats(user.id);
+    setStats(userStats);
+    setLoading(false);
+  }, [user?.id]);
+
+  useEffect(() => {
+    loadStats();
+  }, [loadStats]);
+
   useEffect(() => {
     if (!user?.id) return;
+    const channel = supabase
+      .channel('user-stats')
+      .on(
+        'postgres_changes',
+        { event: '*', schema: 'public', table: 'song_plays', filter: `user_id=eq.${user.id}` },
+        loadStats,
+      )
+      .on(
+        'postgres_changes',
+        { event: '*', schema: 'public', table: 'liked_songs', filter: `user_id=eq.${user.id}` },
+        loadStats,
+      )
+      .on(
+        'postgres_changes',
+        { event: '*', schema: 'public', table: 'playlists', filter: `user_id=eq.${user.id}` },
+        loadStats,
+      )
+      .subscribe();
 
-    const loadStats = async () => {
-      setLoading(true);
-      const userStats = await fetchUserStats(user.id);
-      setStats(userStats);
-      setLoading(false);
+    return () => {
+      supabase.removeChannel(channel);
     };
-
-    loadStats();
-  }, [user?.id]);
+  }, [user?.id, loadStats]);
 
   return { stats, loading };
 }


### PR DESCRIPTION
## Summary
- add glass-styled library modal to track detail screen
- extend MusicProvider for playlist creation and removal
- update TrackMenu and stats hook for playlist management and realtime stats

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68927c4b04a0832483d4ac4384a56844