### PR TITLE
feat: expand social search and profile settings

### DIFF
--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -14,21 +14,22 @@ import {
 import { LinearGradient } from 'expo-linear-gradient';
 import { withAuthGuard } from '@/hoc/withAuthGuard';
 import { useAuth } from '@/providers/AuthProvider';
-import { Track, Playlist, TrackRow } from '@/providers/MusicProvider';
+import { Track, Playlist } from '@/providers/MusicProvider';
 import { supabase } from '@/services/supabase';
-import { apiService } from '@/services/api';
 import { CreditCard as Edit3, LogOut } from 'lucide-react-native';
 import { router } from 'expo-router';
 
 interface Profile {
   id: string;
   email: string;
-  username?: string;
-  first_name?: string;
-  last_name?: string;
+  display_name: string;
   bio?: string;
-  avatar_url?: string;
-  is_private?: boolean;
+  profile_picture_url?: string;
+  is_private: boolean;
+  follower_count: number;
+  following_count: number;
+  show_top_songs?: boolean;
+  show_playlists?: boolean;
 }
 
 function ProfileScreen() {
@@ -36,11 +37,14 @@ function ProfileScreen() {
   const [profile, setProfile] = useState<Profile | null>(null);
   const [loading, setLoading] = useState(true);
   const [editing, setEditing] = useState(false);
-  const [username, setUsername] = useState('');
-  const [firstName, setFirstName] = useState('');
-  const [lastName, setLastName] = useState('');
+  const [displayName, setDisplayName] = useState('');
+  const [avatarUrl, setAvatarUrl] = useState('');
   const [bio, setBio] = useState('');
   const [isPrivate, setIsPrivate] = useState(false);
+  const [showTopSongs, setShowTopSongs] = useState(true);
+  const [showPlaylists, setShowPlaylists] = useState(true);
+  const [followers, setFollowers] = useState(0);
+  const [following, setFollowing] = useState(0);
   const [topSongs, setTopSongs] = useState<Track[]>([]);
   const [publicPlaylists, setPublicPlaylists] = useState<Playlist[]>([]);
 
@@ -54,60 +58,33 @@ function ProfileScreen() {
       const { data: authData } = await supabase.auth.getUser();
       const uid = authData.user?.id;
       if (!uid) throw new Error('No user');
-      const { data, error } = await supabase
-        .from('profiles')
-        .select('*')
-        .eq('id', uid)
-        .single();
-      if (error) throw error;
-      setProfile(data);
-      setUsername(data.username ?? '');
-      setFirstName(data.first_name ?? '');
-      setLastName(data.last_name ?? '');
-      setBio(data.bio ?? '');
-      setIsPrivate(data.is_private ?? false);
 
-      const [songsRes, playlistsRes] = await Promise.all([
-        supabase
-          .from('user_top_songs')
-          .select('play_count, track:track_id(*, artist:artist_id(*))')
-          .eq('user_id', uid)
-          .order('play_count', { ascending: false })
-          .limit(5),
-        supabase
-          .from('playlists')
-          .select('id,title,cover_url')
-          .eq('user_id', uid)
-          .eq('is_public', true),
-      ]);
-
-      interface SongRow {
-        play_count?: number | null;
-        track: TrackRow;
-      }
-
-      const songsData =
-        ((songsRes as { data?: SongRow[] | null })?.data ?? []);
-      setTopSongs(
-        songsData.map((r) => ({
-          id: r.track.id,
-          title: r.track.title,
-          artist: r.track.artist?.name || '',
-          artistId: r.track.artist_id || undefined,
-          album: r.track.album_title || 'Single',
-          duration: r.track.duration || 0,
-          coverUrl: apiService.getPublicUrl('images', r.track.cover_url || ''),
-          audioUrl: apiService.getPublicUrl('audio-files', r.track.audio_url),
-          isLiked: false,
-          genre: '',
-          releaseDate: r.track.release_date || '',
-        })),
+      const { data, error } = await supabase.rpc(
+        'get_user_profile_with_stats',
+        { target_user_id: uid },
       );
-      const plData =
-        ((playlistsRes as {
-          data?: { id: string; title: string; cover_url?: string | null }[] | null;
-        })?.data ?? []);
-      const publicPls = plData.map((p) => ({
+      if (error) throw error;
+      const profileData = data && data.length > 0 ? data[0] : null;
+      if (!profileData) throw new Error('Profile not found');
+
+      setProfile(profileData);
+      setDisplayName(profileData.display_name ?? '');
+      setAvatarUrl(profileData.profile_picture_url ?? '');
+      setBio(profileData.bio ?? '');
+      setIsPrivate(profileData.is_private ?? false);
+      setShowTopSongs(profileData.show_top_songs ?? true);
+      setShowPlaylists(profileData.show_playlists ?? true);
+      setFollowers(profileData.follower_count ?? 0);
+      setFollowing(profileData.following_count ?? 0);
+      setTopSongs(profileData.top_songs || []);
+
+      const { data: playlistsRes } = await supabase
+        .from('playlists')
+        .select('id,title,cover_url')
+        .eq('user_id', uid)
+        .eq('is_public', true);
+
+      const publicPls = (playlistsRes || []).map((p) => ({
         id: p.id,
         title: p.title,
         tracks: [],
@@ -126,19 +103,28 @@ function ProfileScreen() {
     if (!profile) return;
     setLoading(true);
     try {
-      const updates = {
-        username,
-        first_name: firstName,
-        last_name: lastName,
+      const profileUpdates = {
         bio,
+        profile_picture_url: avatarUrl,
         is_private: isPrivate,
+        show_top_songs: showTopSongs,
+        show_playlists: showPlaylists,
       };
       const { error } = await supabase
         .from('profiles')
-        .update(updates)
+        .update(profileUpdates)
         .eq('id', profile.id);
       if (error) throw error;
-      setProfile({ ...profile, ...updates });
+
+      if (displayName !== profile.display_name) {
+        const { error: userErr } = await supabase
+          .from('users')
+          .update({ display_name: displayName })
+          .eq('id', profile.id);
+        if (userErr) throw userErr;
+      }
+
+      setProfile({ ...profile, ...profileUpdates, display_name: displayName });
       setEditing(false);
     } catch (err) {
       console.error(err);
@@ -157,6 +143,28 @@ function ProfileScreen() {
       .update({ is_private: newVal })
       .eq('id', profile.id);
     if (!error) setProfile({ ...profile, is_private: newVal });
+  };
+
+  const toggleShowTopSongs = async () => {
+    if (!profile) return;
+    const newVal = !showTopSongs;
+    setShowTopSongs(newVal);
+    const { error } = await supabase
+      .from('profiles')
+      .update({ show_top_songs: newVal })
+      .eq('id', profile.id);
+    if (!error) setProfile({ ...profile, show_top_songs: newVal });
+  };
+
+  const toggleShowPlaylists = async () => {
+    if (!profile) return;
+    const newVal = !showPlaylists;
+    setShowPlaylists(newVal);
+    const { error } = await supabase
+      .from('profiles')
+      .update({ show_playlists: newVal })
+      .eq('id', profile.id);
+    if (!error) setProfile({ ...profile, show_playlists: newVal });
   };
 
   if (loading) {
@@ -205,7 +213,8 @@ function ProfileScreen() {
           <Image
             source={{
               uri:
-                profile.avatar_url ||
+                avatarUrl ||
+                profile.profile_picture_url ||
                 'https://images.pexels.com/photos/771742/pexels-photo-771742.jpeg?auto=compress&cs=tinysrgb&w=200',
             }}
             style={styles.avatar}
@@ -214,23 +223,16 @@ function ProfileScreen() {
             <>
               <TextInput
                 style={[styles.input, { marginBottom: 8 }]}
-                value={username}
-                onChangeText={setUsername}
-                placeholder="Username"
+                value={displayName}
+                onChangeText={setDisplayName}
+                placeholder="Display name"
                 placeholderTextColor="#64748b"
               />
               <TextInput
                 style={[styles.input, { marginBottom: 8 }]}
-                value={firstName}
-                onChangeText={setFirstName}
-                placeholder="First name"
-                placeholderTextColor="#64748b"
-              />
-              <TextInput
-                style={[styles.input, { marginBottom: 8 }]}
-                value={lastName}
-                onChangeText={setLastName}
-                placeholder="Last name"
+                value={avatarUrl}
+                onChangeText={setAvatarUrl}
+                placeholder="Avatar URL"
                 placeholderTextColor="#64748b"
               />
               <TextInput
@@ -258,12 +260,13 @@ function ProfileScreen() {
             </>
           ) : (
             <>
-              <Text style={styles.name}>{username}</Text>
-              <Text style={styles.fullName}>
-                {`${firstName} ${lastName}`.trim()}
-              </Text>
+              <Text style={styles.name}>{displayName}</Text>
               {bio ? <Text style={styles.bio}>{bio}</Text> : null}
               <Text style={styles.email}>{profile.email}</Text>
+              <View style={styles.statsRow}>
+                <Text style={styles.statText}>{followers} Followers</Text>
+                <Text style={styles.statText}>{following} Following</Text>
+              </View>
               <TouchableOpacity
                 style={styles.editButton}
                 onPress={() => setEditing(true)}
@@ -275,7 +278,7 @@ function ProfileScreen() {
           )}
         </View>
 
-        {topSongs.length > 0 && (
+        {topSongs.length > 0 && showTopSongs && (
           <View
             style={[
               styles.section,
@@ -293,7 +296,7 @@ function ProfileScreen() {
           </View>
         )}
 
-        {publicPlaylists.length > 0 && (
+        {publicPlaylists.length > 0 && showPlaylists && (
           <View
             style={[
               styles.section,
@@ -327,6 +330,14 @@ function ProfileScreen() {
             <Text style={styles.settingLabel}>Private Account</Text>
             <Switch value={isPrivate} onValueChange={togglePrivacy} />
           </View>
+          <View style={styles.settingRow}>
+            <Text style={styles.settingLabel}>Show Top Songs</Text>
+            <Switch value={showTopSongs} onValueChange={toggleShowTopSongs} />
+          </View>
+          <View style={styles.settingRow}>
+            <Text style={styles.settingLabel}>Show Playlists</Text>
+            <Switch value={showPlaylists} onValueChange={toggleShowPlaylists} />
+          </View>
           <TouchableOpacity style={styles.settingRow} onPress={logout}>
             <LogOut color="#ef4444" size={20} />
             <Text
@@ -349,18 +360,21 @@ const styles = StyleSheet.create({
   header: { alignItems: 'center', padding: 24, paddingTop: 60 },
   avatar: { width: 100, height: 100, borderRadius: 50, marginBottom: 12 },
   name: { fontSize: 24, fontFamily: 'Poppins-Bold', color: '#fff' },
-  fullName: {
-    fontSize: 16,
-    color: '#94a3b8',
-    fontFamily: 'Inter-Regular',
-    marginTop: 4,
-  },
   email: { color: '#94a3b8', fontFamily: 'Inter-Regular', marginTop: 4 },
   bio: {
     color: '#94a3b8',
     fontFamily: 'Inter-Regular',
     textAlign: 'center',
     marginTop: 8,
+  },
+  statsRow: {
+    flexDirection: 'row',
+    gap: 16,
+    marginTop: 8,
+  },
+  statText: {
+    color: '#fff',
+    fontFamily: 'Inter-Medium',
   },
   editRow: { flexDirection: 'row', gap: 12 },
   editButton: {


### PR DESCRIPTION
## Summary
- extend search to query playlists and user profiles with live type-ahead results
- load profile data via RPC and add display name/avatar editing with follower stats
- toggle visibility for top songs and playlists from profile settings

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68929abd78148324be581d8025d75ff6