### PR TITLE
Refactor album detail with reusable hero card

### DIFF
--- a/components/AlbumMenu.tsx
+++ b/components/AlbumMenu.tsx
@@ -1,0 +1,104 @@
+import React, { useState } from 'react';
+import {
+  View,
+  Text,
+  TouchableOpacity,
+  Modal,
+  StyleSheet,
+} from 'react-native';
+import { MoreVertical, X } from 'lucide-react-native';
+
+interface Props {
+  onShare: () => void;
+}
+
+export default function AlbumMenu({ onShare }: Props) {
+  const [visible, setVisible] = useState(false);
+
+  return (
+    <>
+      <TouchableOpacity onPress={() => setVisible(true)} style={styles.button}>
+        <MoreVertical color="#94a3b8" size={20} />
+      </TouchableOpacity>
+      <Modal transparent visible={visible} animationType="fade">
+        <View style={styles.overlay}>
+          <View
+            style={[styles.menu, styles.glassCard, styles.brutalBorder, styles.brutalShadow]}
+          >
+            <TouchableOpacity
+              style={styles.close}
+              onPress={() => setVisible(false)}
+            >
+              <X color="#fff" size={20} />
+            </TouchableOpacity>
+            <TouchableOpacity
+              style={styles.menuItem}
+              onPress={() => {
+                onShare();
+                setVisible(false);
+              }}
+            >
+              <Text style={styles.menuText}>Share</Text>
+            </TouchableOpacity>
+            <TouchableOpacity
+              style={styles.menuItem}
+              onPress={() => setVisible(false)}
+            >
+              <Text style={styles.menuText}>Save Album</Text>
+            </TouchableOpacity>
+            <TouchableOpacity
+              style={styles.menuItem}
+              onPress={() => setVisible(false)}
+            >
+              <Text style={styles.menuText}>Report</Text>
+            </TouchableOpacity>
+          </View>
+        </View>
+      </Modal>
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  button: { padding: 8 },
+  overlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.6)',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  menu: {
+    width: 220,
+    padding: 16,
+    borderRadius: 12,
+    backgroundColor: '#1e293b',
+  },
+  close: {
+    position: 'absolute',
+    top: 8,
+    right: 8,
+    padding: 4,
+  },
+  menuItem: { paddingVertical: 12 },
+  menuText: {
+    color: '#fff',
+    fontFamily: 'Inter-SemiBold',
+    fontSize: 16,
+  },
+  glassCard: {
+    backgroundColor: 'rgba(255,255,255,0.05)',
+    borderRadius: 20,
+  },
+  brutalBorder: {
+    borderWidth: 2,
+    borderColor: 'rgba(255,255,255,0.2)',
+  },
+  brutalShadow: {
+    shadowColor: '#000',
+    shadowOffset: { width: 4, height: 4 },
+    shadowOpacity: 0.4,
+    shadowRadius: 6,
+    elevation: 8,
+  },
+});
+

--- a/components/HeroCard.tsx
+++ b/components/HeroCard.tsx
@@ -1,0 +1,202 @@
+import React from 'react';
+import {
+  View,
+  Text,
+  Image,
+  StyleSheet,
+  TouchableOpacity,
+} from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+import { Play, Calendar, Clock, Music } from 'lucide-react-native';
+
+interface Props {
+  coverUrl: string;
+  title: string;
+  subtitle?: string;
+  description?: string;
+  releaseDate?: string;
+  duration?: string;
+  playCount?: number;
+  genres?: string[];
+  onPlay?: () => void;
+  moreMenu?: React.ReactNode;
+}
+
+export default function HeroCard({
+  coverUrl,
+  title,
+  subtitle,
+  description,
+  releaseDate,
+  duration,
+  playCount,
+  genres,
+  onPlay,
+  moreMenu,
+}: Props) {
+  return (
+    <View style={[styles.card, styles.glassCard, styles.brutalBorder, styles.brutalShadow]}>
+      <Image source={{ uri: coverUrl }} style={styles.cover} />
+      {(onPlay || moreMenu) && (
+      <View style={styles.actions}>
+        {onPlay && (
+          <TouchableOpacity style={styles.playButton} onPress={onPlay}>
+            <LinearGradient
+              colors={["#8b5cf6", "#a855f7"]}
+              style={styles.playGradient}
+            >
+              <Play color="#ffffff" size={24} />
+            </LinearGradient>
+          </TouchableOpacity>
+        )}
+        {moreMenu}
+      </View>
+      )}
+      <Text style={styles.title}>{title}</Text>
+      {subtitle && <Text style={styles.subtitle}>{subtitle}</Text>}
+      {description && <Text style={styles.description}>{description}</Text>}
+      {(releaseDate || duration || playCount !== undefined) && (
+        <View style={styles.meta}>
+          {releaseDate && (
+            <View style={styles.metaItem}>
+              <Calendar color="#94a3b8" size={16} />
+              <Text style={styles.metaText}>{releaseDate}</Text>
+            </View>
+          )}
+          {duration && (
+            <View style={styles.metaItem}>
+              <Clock color="#94a3b8" size={16} />
+              <Text style={styles.metaText}>{duration}</Text>
+            </View>
+          )}
+          {playCount !== undefined && (
+            <View style={styles.metaItem}>
+              <Music color="#94a3b8" size={16} />
+              <Text style={styles.metaText}>
+                {playCount.toLocaleString()} plays
+              </Text>
+            </View>
+          )}
+        </View>
+      )}
+      {genres && genres.length > 0 && (
+        <View style={styles.genresContainer}>
+          {genres.map((genre, idx) => (
+            <View key={idx} style={styles.genreTag}>
+              <Text style={styles.genreText}>{genre}</Text>
+            </View>
+          ))}
+        </View>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    alignItems: 'center',
+    paddingHorizontal: 24,
+    paddingBottom: 24,
+    marginBottom: 30,
+  },
+  cover: {
+    width: 280,
+    height: 280,
+    borderRadius: 16,
+    marginBottom: 24,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 8 },
+    shadowOpacity: 0.3,
+    shadowRadius: 16,
+  },
+  actions: {
+    position: 'absolute',
+    top: 16,
+    right: 16,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+  },
+  playButton: {
+    width: 56,
+    height: 56,
+    borderRadius: 28,
+    overflow: 'hidden',
+    elevation: 8,
+    shadowColor: '#8b5cf6',
+    shadowOffset: { width: 0, height: 4 },
+    shadowOpacity: 0.4,
+    shadowRadius: 12,
+  },
+  playGradient: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+  title: {
+    fontSize: 28,
+    fontFamily: 'Poppins-Bold',
+    color: '#ffffff',
+    textAlign: 'center',
+    marginBottom: 8,
+  },
+  subtitle: {
+    fontSize: 20,
+    fontFamily: 'Inter-SemiBold',
+    color: '#a855f7',
+    textAlign: 'center',
+    marginBottom: 12,
+  },
+  description: {
+    fontSize: 16,
+    fontFamily: 'Inter-Regular',
+    color: '#cbd5e1',
+    textAlign: 'center',
+    lineHeight: 24,
+    marginBottom: 20,
+  },
+  meta: {
+    flexDirection: 'row',
+    justifyContent: 'center',
+    flexWrap: 'wrap',
+    gap: 16,
+    marginBottom: 20,
+  },
+  metaItem: { flexDirection: 'row', alignItems: 'center', gap: 6 },
+  metaText: {
+    fontSize: 14,
+    fontFamily: 'Inter-Regular',
+    color: '#94a3b8',
+  },
+  genresContainer: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    justifyContent: 'center',
+    gap: 8,
+  },
+  genreTag: {
+    backgroundColor: 'rgba(139,92,246,0.2)',
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 16,
+    borderWidth: 1,
+    borderColor: 'rgba(139,92,246,0.3)',
+  },
+  genreText: {
+    fontSize: 12,
+    fontFamily: 'Inter-Medium',
+    color: '#8b5cf6',
+  },
+  glassCard: {
+    backgroundColor: 'rgba(255,255,255,0.05)',
+    borderRadius: 20,
+  },
+  brutalBorder: {
+    borderWidth: 2,
+    borderColor: 'rgba(255,255,255,0.2)',
+  },
+  brutalShadow: {
+    shadowColor: '#000',
+    shadowOffset: { width: 4, height: 4 },
+    shadowOpacity: 0.4,
+    shadowRadius: 6,
+    elevation: 8,
+  },
+});
+


### PR DESCRIPTION
## Summary
- add reusable `HeroCard` for cover art, metadata and actions
- implement `AlbumMenu` with Share/Save/Report options
- refactor album detail screen to use `HeroCard`, add play-all and tracklist heading

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6892a8c644088324855ec4672a53faf1