### PR TITLE
chore: add album detail debugging logs

### DIFF
--- a/app/(detail)/album/[id].tsx
+++ b/app/(detail)/album/[id].tsx
@@ -45,6 +45,17 @@ function AlbumDetailScreen() {
     setError(null);
     try {
       const albumData = await apiService.getAlbumById(id!);
+      console.log('AlbumDetailScreen: fetched album', {
+        id: albumData?.id,
+        title: albumData?.title,
+        coverUrl: albumData?.cover_url,
+      });
+      if (!albumData?.cover_url) {
+        console.warn('AlbumDetailScreen: album missing cover art', id);
+      }
+      if (!albumData?.tracks || albumData.tracks.length === 0) {
+        console.warn('AlbumDetailScreen: album has no tracks', id);
+      }
       setAlbum(albumData);
 
       const transformed = (albumData.tracks || []).map(
@@ -73,6 +84,15 @@ function AlbumDetailScreen() {
 
 
       transformed.sort((a, b) => (a.trackNumber ?? 0) - (b.trackNumber ?? 0));
+      transformed.forEach((t) => {
+        if (!t.audioUrl) {
+          console.warn('AlbumDetailScreen: track missing audio URL', t.id);
+        }
+        if (!t.coverUrl) {
+          console.warn('AlbumDetailScreen: track missing cover art', t.id);
+        }
+      });
+      console.log('AlbumDetailScreen: loaded tracks', transformed.length);
       setTracks(transformed);
 
       const totalDuration = transformed.reduce(
@@ -94,6 +114,18 @@ function AlbumDetailScreen() {
   };
 
   const handleTrackPlay = (track: Track) => {
+    console.log('AlbumDetailScreen: play track', {
+      id: track.id,
+      title: track.title,
+      audioUrl: track.audioUrl,
+      coverUrl: track.coverUrl,
+    });
+    if (!track.audioUrl) {
+      console.warn('AlbumDetailScreen: cannot play track without audio', track.id);
+    }
+    if (!track.coverUrl) {
+      console.warn('AlbumDetailScreen: track missing cover art', track.id);
+    }
     if (currentTrack?.id === track.id) {
       if (isPlaying) {
         pauseTrack();
@@ -106,7 +138,14 @@ function AlbumDetailScreen() {
   };
 
   const handlePlayAlbum = () => {
-    if (tracks.length === 0) return;
+    console.log('AlbumDetailScreen: play album', {
+      albumId: album?.id,
+      trackCount: tracks.length,
+    });
+    if (tracks.length === 0) {
+      console.warn('AlbumDetailScreen: no tracks to play for album', album?.id);
+      return;
+    }
     const first = tracks[0];
     if (currentTrack?.id === first.id) {
       if (isPlaying) pauseTrack();


### PR DESCRIPTION
## Summary
- add extensive console logging to album detail page for troubleshooting track playback and missing assets

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6893668677e08324903077ee9a2bdc98