### PR TITLE
fix: clean up track metadata typing

### DIFF
--- a/app/(detail)/album/[id].tsx
+++ b/app/(detail)/album/[id].tsx
@@ -59,28 +59,35 @@ function AlbumDetailScreen() {
       setAlbum(albumData);
 
       const transformed = (albumData.tracks || []).map(
-        (t: TrackData, idx: number): Track => ({
-          id: t.id,
-          title: t.title,
-          artist: t.artist?.name || albumData.artist?.name || 'Unknown Artist',
-          artistId: t.artist?.id || albumData.artist_id || undefined,
-          album: albumData.title,
-          duration: t.duration,
-          coverUrl: albumData.cover_url,
-          audioUrl: t.audio_url,
-          isLiked: likedSongIds.includes(t.id),
-          trackNumber: t.track_number ?? idx + 1,
-          releaseDate: albumData.release_date || '',
-          playCount: t.play_count ?? undefined,
-          likeCount: t.like_count ?? undefined,
-          lyrics: t.lyrics || undefined,
-          genre: '',
-          year: albumData.release_date
-            ? new Date(albumData.release_date).getFullYear().toString()
-            : undefined,
-          description: '',
-          featuredArtists: t.featured_artists,
-        }),
+        (t: TrackData, idx: number): Track => {
+          const mainArtistName =
+            t.artist?.name || albumData.artist?.name || 'Unknown Artist';
+
+          return {
+            id: t.id,
+            title: t.title,
+            artist: mainArtistName,
+            artistId: t.artist?.id || albumData.artist_id || undefined,
+            album: albumData.title,
+            duration: t.duration,
+            coverUrl: apiService.getPublicUrl('images', albumData.cover_url),
+            audioUrl: apiService.getPublicUrl('audio-files', t.audio_url),
+            isLiked: likedSongIds.includes(t.id),
+            trackNumber: t.track_number ?? idx + 1,
+            releaseDate: albumData.release_date || '',
+            playCount:
+              typeof t.play_count === 'number' ? t.play_count : undefined,
+            likeCount:
+              typeof t.like_count === 'number' ? t.like_count : undefined,
+            lyrics: t.lyrics || undefined,
+            genre: '',
+            year: albumData.release_date
+              ? new Date(albumData.release_date).getFullYear().toString()
+              : undefined,
+            description: '',
+            featuredArtists: t.featured_artists,
+          };
+        },
       );
 
 

--- a/app/(detail)/playlist/[id].tsx
+++ b/app/(detail)/playlist/[id].tsx
@@ -92,7 +92,8 @@ export default function PlaylistDetailScreen() {
             ? t.genres[0]
             : (t.genres as string) || '',
           releaseDate: t.release_date || t.created_at || '',
-          playCount: t.play_count || undefined,
+          playCount:
+            typeof t.play_count === 'number' ? t.play_count : undefined,
         }));
         const ordered = playlist.trackIds
           .map((tid) => mapped.find((m) => m.id === tid))

--- a/app/(detail)/track/[id].tsx
+++ b/app/(detail)/track/[id].tsx
@@ -64,11 +64,11 @@ export default function TrackDetailScreen() {
         artistId: data.artist_id || undefined,
         album: data.album?.title || 'Single',
         duration: data.duration || 180,
-        coverUrl:
-          data.cover_url ||
-          data.album?.cover_url ||
-          'https://images.pexels.com/photos/167092/pexels-photo-167092.jpeg?auto=compress&cs=tinysrgb&w=400',
-        audioUrl: data.audio_url,
+        coverUrl: apiService.getPublicUrl(
+          'images',
+          data.cover_url || data.album?.cover_url || '',
+        ),
+        audioUrl: apiService.getPublicUrl('audio-files', data.audio_url),
         isLiked: likedSongIds.includes(data.id),
         genre: Array.isArray(data.genres)
           ? data.genres[0]
@@ -79,8 +79,10 @@ export default function TrackDetailScreen() {
         year: data.release_date
           ? new Date(data.release_date).getFullYear().toString()
           : undefined,
-        playCount: data.play_count,
-        likeCount: data.like_count,
+        playCount:
+          typeof data.play_count === 'number' ? data.play_count : undefined,
+        likeCount:
+          typeof data.like_count === 'number' ? data.like_count : undefined,
         lyrics: data.lyrics || '',
         description: data.description || '',
         genres: data.genres || undefined,

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -84,7 +84,7 @@ interface DatabaseTrack {
   duration: number | null;
   audio_url: string;
   cover_url: string;
-  artist: { name: string } | null;
+  artist: { name: string } | { name: string }[] | null;
 }
 
 // Database artist interface
@@ -194,19 +194,26 @@ export default function ProfileScreen() {
 
       if (error) throw error;
 
-      const tracks: Track[] = (data as DatabaseTrack[])?.map(track => ({
-        id: track.id,
-        title: track.title,
-        artist: track.artist?.name || 'Unknown Artist',
-        duration: track.duration || 0,
-        audioUrl: apiService.getPublicUrl('audio-files', track.audio_url),
-        coverUrl: apiService.getPublicUrl('images', track.cover_url),
-        // Add required Track properties with defaults
-        album: 'Unknown Album',
-        isLiked: false,
-        genre: 'Unknown',
-        releaseDate: new Date().getFullYear().toString(),
-      })) || [];
+      const tracks: Track[] =
+        (data as DatabaseTrack[])?.map((track) => {
+          const artistName = Array.isArray(track.artist)
+            ? track.artist[0]?.name
+            : track.artist?.name;
+
+          return {
+            id: track.id,
+            title: track.title,
+            artist: artistName || 'Unknown Artist',
+            duration: track.duration || 0,
+            audioUrl: apiService.getPublicUrl('audio-files', track.audio_url),
+            coverUrl: apiService.getPublicUrl('images', track.cover_url),
+            // Add required Track properties with defaults
+            album: 'Unknown Album',
+            isLiked: false,
+            genre: 'Unknown',
+            releaseDate: new Date().getFullYear().toString(),
+          };
+        }) || [];
 
       setTopTracks(tracks);
     } catch (error) {

--- a/app/player.tsx
+++ b/app/player.tsx
@@ -152,14 +152,16 @@ export default function PlayerScreen() {
           <TouchableOpacity
             onPress={() =>
               currentTrack.artistId &&
-              router.push(`/artist/${currentTrack.artistId}`)
+              router.push(`/artist/${currentTrack.artistId}` as const)
             }
           >
             <Text style={styles.artist}>{currentTrack.artist}</Text>
           </TouchableOpacity>
           {currentTrack.albumId && (
             <TouchableOpacity
-              onPress={() => router.push(`/album/${currentTrack.albumId}`)}
+              onPress={() =>
+                router.push(`/album/${currentTrack.albumId}` as const)
+              }
             >
               <Text style={styles.album}>{currentTrack.album}</Text>
             </TouchableOpacity>

--- a/components/HeroCard.tsx
+++ b/components/HeroCard.tsx
@@ -39,7 +39,7 @@ export default function Hero({
           style={styles.subtitle}
           onPress={() =>
             router.push({
-              pathname: `/artist/${mainArtist.id}`,
+              pathname: `/artist/${mainArtist.id}` as const,
               params: { artist: JSON.stringify(mainArtist) },
             })
           }
@@ -58,7 +58,7 @@ export default function Hero({
               style={styles.featured}
               onPress={() =>
                 router.push({
-                  pathname: `/artist/${a.id}`,
+                  pathname: `/artist/${a.id}` as const,
                   params: { artist: JSON.stringify(a) },
                 })
               }

--- a/components/TrackItem.tsx
+++ b/components/TrackItem.tsx
@@ -26,7 +26,7 @@ export default function TrackItem({
     <View style={[styles.row, isCurrent && styles.currentRow]}>
       <TouchableOpacity
         style={styles.info}
-        onPress={() => router.push(`/track/${track.id}`)}
+        onPress={() => router.push(`/track/${track.id}` as const)}
         onLongPress={onLongPress}
       >
         <Image source={{ uri: track.coverUrl }} style={styles.image} />
@@ -40,7 +40,7 @@ export default function TrackItem({
               onPress={() =>
                 track.artistId
                   ? router.push({
-                      pathname: `/artist/${track.artistId}`,
+                      pathname: `/artist/${track.artistId}` as const,
                       params: {
                         artist: JSON.stringify({
                           id: track.artistId,
@@ -61,8 +61,8 @@ export default function TrackItem({
                     key={a.id}
                     style={styles.artist}
                     onPress={() =>
-                      router.push({
-                        pathname: `/artist/${a.id}`,
+                    router.push({
+                        pathname: `/artist/${a.id}` as const,
                         params: { artist: JSON.stringify(a) },
                       })
                     }


### PR DESCRIPTION
## Summary
- narrow nullable play/like counts on detail pages
- type artist routes and top-track artist results safely
- resolve media URLs with getPublicUrl

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68938a0393148324bd70d5c71e368b5b