### PR TITLE
feat: enhance artist detail page

### DIFF
--- a/components/TrackItem.tsx
+++ b/components/TrackItem.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { View, Text, Image, StyleSheet, TouchableOpacity } from 'react-native';
-import { Play, Pause } from 'lucide-react-native';
-import { Track } from '@/providers/MusicProvider';
+import { Play, Pause, Heart } from 'lucide-react-native';
+import { Track, useMusic } from '@/providers/MusicProvider';
 import TrackOptionsMenu from './TrackOptionsMenu';
 import { router } from 'expo-router';
 
@@ -12,6 +12,8 @@ interface Props {
   isPlaying?: boolean;
   onPlay: () => void;
   onLongPress?: () => void;
+  showLikeButton?: boolean;
+  showOptionsMenu?: boolean;
 }
 
 export default function TrackItem({
@@ -21,7 +23,11 @@ export default function TrackItem({
   isPlaying,
   onPlay,
   onLongPress,
+  showLikeButton,
+  showOptionsMenu = true,
 }: Props) {
+  const { toggleLike, likedSongIds } = useMusic();
+  const isLiked = track.isLiked || likedSongIds.includes(track.id);
   return (
     <View style={[styles.row, isCurrent && styles.currentRow]}>
       <TouchableOpacity
@@ -76,7 +82,21 @@ export default function TrackItem({
           </Text>
         </View>
       </TouchableOpacity>
-      <TrackOptionsMenu track={track} playlistId={playlistId} />
+      {showOptionsMenu && (
+        <TrackOptionsMenu track={track} playlistId={playlistId} />
+      )}
+      {showLikeButton && (
+        <TouchableOpacity
+          style={[styles.action, styles.brutalBorder]}
+          onPress={() => toggleLike(track.id)}
+        >
+          <Heart
+            color={isLiked ? '#ef4444' : '#8b5cf6'}
+            fill={isLiked ? '#ef4444' : 'transparent'}
+            size={16}
+          />
+        </TouchableOpacity>
+      )}
       <TouchableOpacity
         style={[styles.action, styles.brutalBorder]}
         onPress={onPlay}

--- a/components/TrackList.tsx
+++ b/components/TrackList.tsx
@@ -12,6 +12,8 @@ interface Props {
   playlistId?: string;
   editable?: boolean;
   onReorder?: (tracks: Track[]) => void;
+  showLikeButton?: boolean;
+  showOptionsMenu?: boolean;
 }
 
 export default function TrackList({
@@ -22,6 +24,8 @@ export default function TrackList({
   playlistId,
   editable,
   onReorder,
+  showLikeButton,
+  showOptionsMenu = true,
 }: Props) {
   if (editable) {
     const renderItem = ({ item, drag }: RenderItemParams<Track>) => (
@@ -32,6 +36,8 @@ export default function TrackList({
         isPlaying={isPlaying}
         onPlay={() => onPlay(item)}
         onLongPress={drag}
+        showLikeButton={showLikeButton}
+        showOptionsMenu={showOptionsMenu}
       />
     );
 
@@ -56,6 +62,8 @@ export default function TrackList({
             isCurrent={currentTrackId === t.id}
             isPlaying={isPlaying}
             onPlay={() => onPlay(t)}
+            showLikeButton={showLikeButton}
+            showOptionsMenu={showOptionsMenu}
           />
         </View>
       ))}


### PR DESCRIPTION
## Summary
- add album release dates and appearances query
- show like buttons in track lists and items
- build rich artist detail page with most recent release, top songs, singles, albums, and appears on

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689393befa148324ab281281ae67f946