### PR TITLE
feat: enhance artist pages and library

### DIFF
--- a/app/(detail)/artist/[id]/albums.tsx
+++ b/app/(detail)/artist/[id]/albums.tsx
@@ -1,0 +1,150 @@
+import React, { useEffect, useState } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  TouchableOpacity,
+  ActivityIndicator,
+  Image,
+} from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+import { useLocalSearchParams, useRouter } from 'expo-router';
+import { ArrowLeft } from 'lucide-react-native';
+import { apiService } from '@/services/api';
+
+interface AlbumSummary {
+  id: string;
+  title: string;
+  cover_url: string;
+  release_date: string;
+}
+
+export default function ArtistAlbumsScreen() {
+  const { id } = useLocalSearchParams<{ id: string }>();
+  const router = useRouter();
+  const [albums, setAlbums] = useState<AlbumSummary[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    if (id) loadAlbums();
+  }, [id]);
+
+  const loadAlbums = async () => {
+    setIsLoading(true);
+    try {
+      const data = await apiService.getArtistAlbums(id!);
+      setAlbums(data);
+    } catch (err) {
+      console.error(err);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <LinearGradient colors={['#1a1a2e', '#16213e', '#0f3460']} style={styles.container}>
+        <ActivityIndicator size="large" color="#8b5cf6" />
+      </LinearGradient>
+    );
+  }
+
+  return (
+    <LinearGradient colors={['#1a1a2e', '#16213e', '#0f3460']} style={styles.container}>
+      <View style={styles.header}>
+        <TouchableOpacity onPress={() => router.back()}>
+          <ArrowLeft color="#fff" size={24} />
+        </TouchableOpacity>
+        <Text style={styles.title}>Albums</Text>
+        <View style={{ width: 24 }} />
+      </View>
+      <View style={styles.list}>
+        {albums.map((item) => (
+          <TouchableOpacity
+            key={item.id}
+            style={[
+              styles.albumCard,
+              styles.glassCard,
+              styles.brutalBorder,
+              styles.brutalShadow,
+            ]}
+            onPress={() => router.push(`/album/${item.id}` as const)}
+          >
+            <Image source={{ uri: item.cover_url }} style={styles.cover} />
+            <View style={styles.meta}>
+              <Text style={styles.albumTitle} numberOfLines={1}>
+                {item.title}
+              </Text>
+              <Text style={styles.albumDate}>
+                {new Date(item.release_date).toLocaleDateString()}
+              </Text>
+            </View>
+          </TouchableOpacity>
+        ))}
+      </View>
+    </LinearGradient>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    paddingTop: 50,
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 16,
+    marginBottom: 16,
+  },
+  title: {
+    fontSize: 20,
+    fontFamily: 'Poppins-Bold',
+    color: '#fff',
+  },
+  list: {
+    paddingHorizontal: 16,
+  },
+  albumCard: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: 16,
+    padding: 12,
+    borderRadius: 12,
+  },
+  cover: {
+    width: 60,
+    height: 60,
+    borderRadius: 8,
+    marginRight: 12,
+  },
+  meta: { flex: 1 },
+  albumTitle: {
+    fontSize: 16,
+    fontFamily: 'Inter-SemiBold',
+    color: '#fff',
+  },
+  albumDate: {
+    fontSize: 12,
+    fontFamily: 'Inter-Regular',
+    color: '#94a3b8',
+    marginTop: 4,
+  },
+  glassCard: {
+    backgroundColor: 'rgba(255,255,255,0.05)',
+    borderRadius: 20,
+  },
+  brutalBorder: {
+    borderWidth: 2,
+    borderColor: 'rgba(255,255,255,0.2)',
+  },
+  brutalShadow: {
+    shadowColor: '#000',
+    shadowOffset: { width: 4, height: 4 },
+    shadowOpacity: 0.4,
+    shadowRadius: 6,
+    elevation: 8,
+  },
+});
+

--- a/app/(detail)/artist/[id]/appears-on.tsx
+++ b/app/(detail)/artist/[id]/appears-on.tsx
@@ -1,0 +1,135 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, StyleSheet, TouchableOpacity, ActivityIndicator } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+import { useLocalSearchParams, useRouter } from 'expo-router';
+import { ArrowLeft } from 'lucide-react-native';
+import { useMusic, Track } from '@/providers/MusicProvider';
+import { apiService } from '@/services/api';
+import TrackList from '@/components/TrackList';
+
+interface TrackDetailsRow {
+  id: string;
+  title: string;
+  artist_id?: string | null;
+  artist?: { name?: string } | null;
+  album_id?: string | null;
+  album?: { title?: string; cover_url?: string | null } | null;
+  duration?: number | null;
+  cover_url?: string | null;
+  audio_url: string;
+  genres?: string[] | string | null;
+  release_date?: string | null;
+  play_count?: number | null;
+  track_number?: number | null;
+  like_count?: number | null;
+  lyrics?: string | null;
+  featured_artists?: { id: string; name: string }[];
+}
+
+export default function ArtistAppearsOnScreen() {
+  const { id } = useLocalSearchParams<{ id: string }>();
+  const router = useRouter();
+  const { currentTrack, isPlaying, playTrack, pauseTrack, likedSongIds } =
+    useMusic();
+  const [tracks, setTracks] = useState<Track[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    if (id) loadTracks();
+  }, [id]);
+
+  const transformTrack = (t: TrackDetailsRow): Track => ({
+    id: t.id,
+    title: t.title,
+    artist: t.artist?.name || 'Unknown',
+    artistId: t.artist_id || undefined,
+    album: t.album?.title || 'Unknown Album',
+    albumId: t.album_id || undefined,
+    duration: t.duration ?? 0,
+    coverUrl:
+      t.cover_url ||
+      t.album?.cover_url ||
+      'https://images.pexels.com/photos/167092/pexels-photo-167092.jpeg?auto=compress&cs=tinysrgb&w=400',
+    audioUrl: t.audio_url,
+    isLiked: likedSongIds.includes(t.id),
+    genre: Array.isArray(t.genres)
+      ? String(t.genres[0] || '')
+      : typeof t.genres === 'string'
+        ? t.genres
+        : '',
+    genres: Array.isArray(t.genres) ? t.genres : t.genres ? [t.genres] : [],
+    releaseDate: t.release_date || '',
+    playCount: t.play_count ?? 0,
+    likeCount: t.like_count ?? 0,
+    trackNumber: t.track_number ?? undefined,
+    lyrics: t.lyrics ?? undefined,
+    featuredArtists: t.featured_artists || [],
+  });
+
+  const loadTracks = async () => {
+    setIsLoading(true);
+    try {
+      const rows = await apiService.getArtistAppearances(id!);
+      setTracks(rows.map(transformTrack));
+    } catch (err) {
+      console.error(err);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleTrackPress = (track: Track) => {
+    if (currentTrack?.id === track.id) {
+      if (isPlaying) pauseTrack();
+      else playTrack(track, tracks);
+    } else {
+      playTrack(track, tracks);
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <LinearGradient colors={['#1a1a2e', '#16213e', '#0f3460']} style={styles.container}>
+        <ActivityIndicator size="large" color="#8b5cf6" />
+      </LinearGradient>
+    );
+  }
+
+  return (
+    <LinearGradient colors={['#1a1a2e', '#16213e', '#0f3460']} style={styles.container}>
+      <View style={styles.header}>
+        <TouchableOpacity onPress={() => router.back()}>
+          <ArrowLeft color="#fff" size={24} />
+        </TouchableOpacity>
+        <Text style={styles.title}>Appears On</Text>
+        <View style={{ width: 24 }} />
+      </View>
+      <TrackList
+        tracks={tracks}
+        currentTrackId={currentTrack?.id}
+        isPlaying={isPlaying}
+        onPlay={handleTrackPress}
+      />
+    </LinearGradient>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    paddingTop: 50,
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 16,
+    marginBottom: 16,
+  },
+  title: {
+    fontSize: 20,
+    fontFamily: 'Poppins-Bold',
+    color: '#fff',
+  },
+});
+

--- a/app/(detail)/artist/[id]/index.tsx
+++ b/app/(detail)/artist/[id]/index.tsx
@@ -8,7 +8,6 @@ import {
   ActivityIndicator,
   Platform,
   ScrollView,
-  FlatList,
 } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
 import { useLocalSearchParams, useRouter } from 'expo-router';
@@ -21,7 +20,8 @@ import {
   UserPlus,
   UserCheck,
 } from 'lucide-react-native';
-import MiniTrackCard from '@/components/MiniTrackCard';
+import TrackList from '@/components/TrackList';
+import TrackItem from '@/components/TrackItem';
 
 interface Artist {
   id: string;
@@ -296,106 +296,90 @@ export default function ArtistDetailScreen() {
         {recentRelease && (
           <View style={styles.section}>
             <Text style={styles.sectionTitle}>Most Recent Release</Text>
-            <ScrollView
-              horizontal
-              showsHorizontalScrollIndicator={false}
-              contentContainerStyle={styles.horizontalList}
-            >
-              {recentRelease.type === 'track' ? (
-                <MiniTrackCard
-                  track={recentRelease.item}
-                  isCurrent={currentTrack?.id === recentRelease.item.id}
-                  isPlaying={isPlaying}
-                  onPlay={() =>
-                    handleTrackPress(recentRelease.item, [recentRelease.item])
-                  }
-                  showLikeButton
+            {recentRelease.type === 'track' ? (
+              <TrackItem
+                track={recentRelease.item}
+                isCurrent={currentTrack?.id === recentRelease.item.id}
+                isPlaying={isPlaying}
+                onPlay={() =>
+                  handleTrackPress(recentRelease.item, [recentRelease.item])
+                }
+                showLikeButton
+              />
+            ) : (
+              <TouchableOpacity
+                style={[
+                  styles.albumCard,
+                  styles.glassCard,
+                  styles.brutalBorder,
+                  styles.brutalShadow,
+                ]}
+                onPress={() =>
+                  router.push(`/album/${recentRelease.item.id}` as const)
+                }
+              >
+                <Image
+                  source={{ uri: recentRelease.item.cover_url }}
+                  style={styles.albumCover}
                 />
-              ) : (
-                <TouchableOpacity
-                  style={[
-                    styles.albumCard,
-                    styles.glassCard,
-                    styles.brutalBorder,
-                    styles.brutalShadow,
-                  ]}
-                  onPress={() =>
-                    router.push(`/album/${recentRelease.item.id}` as const)
-                  }
-                >
-                  <Image
-                    source={{ uri: recentRelease.item.cover_url }}
-                    style={styles.albumCover}
-                  />
-                  <Text style={styles.albumTitle} numberOfLines={1}>
-                    {recentRelease.item.title}
-                  </Text>
-                  <Text style={styles.albumDate}>
-                    {new Date(
-                      recentRelease.item.release_date,
-                    ).toLocaleDateString()}
-                  </Text>
-                </TouchableOpacity>
-              )}
-            </ScrollView>
+                <Text style={styles.albumTitle} numberOfLines={1}>
+                  {recentRelease.item.title}
+                </Text>
+                <Text style={styles.albumDate}>
+                  {new Date(
+                    recentRelease.item.release_date,
+                  ).toLocaleDateString()}
+                </Text>
+              </TouchableOpacity>
+            )}
           </View>
         )}
 
         {topTracks.length > 0 && (
           <View style={styles.section}>
             <Text style={styles.sectionTitle}>Top Songs</Text>
-            <FlatList
-              data={topTracks}
-              horizontal
-              keyExtractor={(item) => item.id}
-              showsHorizontalScrollIndicator={false}
-              contentContainerStyle={styles.horizontalList}
-              renderItem={({ item }) => (
-                <MiniTrackCard
-                  track={item}
-                  isCurrent={currentTrack?.id === item.id}
-                  isPlaying={isPlaying}
-                  onPlay={() => handleTrackPress(item, topTracks)}
-                  showLikeButton
-                />
-              )}
+            <TrackList
+              tracks={topTracks.slice(0, 5)}
+              currentTrackId={currentTrack?.id}
+              isPlaying={isPlaying}
+              onPlay={(t) => handleTrackPress(t, topTracks)}
             />
           </View>
         )}
 
         {singles.length > 0 && (
           <View style={styles.section}>
-            <Text style={styles.sectionTitle}>Singles</Text>
-            <FlatList
-              data={singles}
-              horizontal
-              keyExtractor={(item) => item.id}
-              showsHorizontalScrollIndicator={false}
-              contentContainerStyle={styles.horizontalList}
-              renderItem={({ item }) => (
-                <MiniTrackCard
-                  track={item}
-                  isCurrent={currentTrack?.id === item.id}
-                  isPlaying={isPlaying}
-                  onPlay={() => handleTrackPress(item, singles)}
-                  showLikeButton
-                />
-              )}
+            <View style={styles.sectionHeader}>
+              <Text style={styles.sectionTitle}>Singles</Text>
+              <TouchableOpacity
+                onPress={() => router.push(`/artist/${id}/singles` as const)}
+              >
+                <Text style={styles.showAll}>Show All</Text>
+              </TouchableOpacity>
+            </View>
+            <TrackList
+              tracks={singles.slice(0, 5)}
+              currentTrackId={currentTrack?.id}
+              isPlaying={isPlaying}
+              onPlay={(t) => handleTrackPress(t, singles)}
             />
           </View>
         )}
 
         {albums.length > 0 && (
           <View style={styles.section}>
-            <Text style={styles.sectionTitle}>Albums</Text>
-            <FlatList
-              data={albums}
-              horizontal
-              keyExtractor={(item) => item.id}
-              showsHorizontalScrollIndicator={false}
-              contentContainerStyle={styles.horizontalList}
-              renderItem={({ item }) => (
+            <View style={styles.sectionHeader}>
+              <Text style={styles.sectionTitle}>Albums</Text>
+              <TouchableOpacity
+                onPress={() => router.push(`/artist/${id}/albums` as const)}
+              >
+                <Text style={styles.showAll}>Show All</Text>
+              </TouchableOpacity>
+            </View>
+            <View style={styles.albumList}>
+              {albums.slice(0, 5).map((item) => (
                 <TouchableOpacity
+                  key={item.id}
                   style={[
                     styles.albumCard,
                     styles.glassCard,
@@ -415,29 +399,26 @@ export default function ArtistDetailScreen() {
                     {new Date(item.release_date).toLocaleDateString()}
                   </Text>
                 </TouchableOpacity>
-              )}
-            />
+              ))}
+            </View>
           </View>
         )}
 
         {appearsOn.length > 0 && (
           <View style={styles.section}>
-            <Text style={styles.sectionTitle}>Appears On</Text>
-            <FlatList
-              data={appearsOn}
-              horizontal
-              keyExtractor={(item) => item.id}
-              showsHorizontalScrollIndicator={false}
-              contentContainerStyle={styles.horizontalList}
-              renderItem={({ item }) => (
-                <MiniTrackCard
-                  track={item}
-                  isCurrent={currentTrack?.id === item.id}
-                  isPlaying={isPlaying}
-                  onPlay={() => handleTrackPress(item, appearsOn)}
-                  showLikeButton
-                />
-              )}
+            <View style={styles.sectionHeader}>
+              <Text style={styles.sectionTitle}>Appears On</Text>
+              <TouchableOpacity
+                onPress={() => router.push(`/artist/${id}/appears-on` as const)}
+              >
+                <Text style={styles.showAll}>Show All</Text>
+              </TouchableOpacity>
+            </View>
+            <TrackList
+              tracks={appearsOn.slice(0, 5)}
+              currentTrackId={currentTrack?.id}
+              isPlaying={isPlaying}
+              onPlay={(t) => handleTrackPress(t, appearsOn)}
             />
           </View>
         )}
@@ -507,14 +488,24 @@ const styles = StyleSheet.create({
   section: {
     marginBottom: 32,
   },
+  sectionHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingHorizontal: 16,
+    marginBottom: 16,
+  },
   sectionTitle: {
     fontSize: 20,
     fontFamily: 'Poppins-Bold',
     color: '#fff',
-    marginBottom: 16,
-    paddingHorizontal: 16,
   },
-  horizontalList: {
+  showAll: {
+    fontSize: 14,
+    fontFamily: 'Inter-SemiBold',
+    color: '#8b5cf6',
+  },
+  albumList: {
     paddingHorizontal: 16,
   },
   albumCard: {

--- a/app/(detail)/artist/[id]/singles.tsx
+++ b/app/(detail)/artist/[id]/singles.tsx
@@ -1,0 +1,143 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, StyleSheet, TouchableOpacity, ActivityIndicator } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+import { useLocalSearchParams, useRouter } from 'expo-router';
+import { ArrowLeft } from 'lucide-react-native';
+import { useMusic, Track } from '@/providers/MusicProvider';
+import { apiService } from '@/services/api';
+import TrackList from '@/components/TrackList';
+
+interface TrackDetailsRow {
+  id: string;
+  title: string;
+  artist_id?: string | null;
+  artist?: { name?: string } | null;
+  album_id?: string | null;
+  album?: { title?: string; cover_url?: string | null } | null;
+  duration?: number | null;
+  cover_url?: string | null;
+  audio_url: string;
+  genres?: string[] | string | null;
+  release_date?: string | null;
+  play_count?: number | null;
+  track_number?: number | null;
+  like_count?: number | null;
+  lyrics?: string | null;
+  featured_artists?: { id: string; name: string }[];
+}
+
+export default function ArtistSinglesScreen() {
+  const { id } = useLocalSearchParams<{ id: string }>();
+  const router = useRouter();
+  const { currentTrack, isPlaying, playTrack, pauseTrack, likedSongIds } =
+    useMusic();
+  const [singles, setSingles] = useState<Track[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    if (id) loadSingles();
+  }, [id]);
+
+  const transformTrack = (t: TrackDetailsRow): Track => ({
+    id: t.id,
+    title: t.title,
+    artist: t.artist?.name || 'Unknown',
+    artistId: t.artist_id || undefined,
+    album: t.album?.title || 'Unknown Album',
+    albumId: t.album_id || undefined,
+    duration: t.duration ?? 0,
+    coverUrl:
+      t.cover_url ||
+      t.album?.cover_url ||
+      'https://images.pexels.com/photos/167092/pexels-photo-167092.jpeg?auto=compress&cs=tinysrgb&w=400',
+    audioUrl: t.audio_url,
+    isLiked: likedSongIds.includes(t.id),
+    genre: Array.isArray(t.genres)
+      ? String(t.genres[0] || '')
+      : typeof t.genres === 'string'
+        ? t.genres
+        : '',
+    genres: Array.isArray(t.genres) ? t.genres : t.genres ? [t.genres] : [],
+    releaseDate: t.release_date || '',
+    playCount: t.play_count ?? 0,
+    likeCount: t.like_count ?? 0,
+    trackNumber: t.track_number ?? undefined,
+    lyrics: t.lyrics ?? undefined,
+    featuredArtists: t.featured_artists || [],
+  });
+
+  const loadSingles = async () => {
+    setIsLoading(true);
+    try {
+      const trackRows = await apiService.getArtistTracks(id!);
+      const allTracks = trackRows.map(transformTrack);
+      const singleTracks = allTracks
+        .filter((t) => !t.albumId)
+        .sort(
+          (a, b) =>
+            new Date(b.releaseDate).getTime() -
+            new Date(a.releaseDate).getTime(),
+        );
+      setSingles(singleTracks);
+    } catch (err) {
+      console.error(err);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleTrackPress = (track: Track) => {
+    if (currentTrack?.id === track.id) {
+      if (isPlaying) pauseTrack();
+      else playTrack(track, singles);
+    } else {
+      playTrack(track, singles);
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <LinearGradient colors={['#1a1a2e', '#16213e', '#0f3460']} style={styles.container}>
+        <ActivityIndicator size="large" color="#8b5cf6" />
+      </LinearGradient>
+    );
+  }
+
+  return (
+    <LinearGradient colors={['#1a1a2e', '#16213e', '#0f3460']} style={styles.container}>
+      <View style={styles.header}>
+        <TouchableOpacity onPress={() => router.back()}>
+          <ArrowLeft color="#fff" size={24} />
+        </TouchableOpacity>
+        <Text style={styles.title}>Singles</Text>
+        <View style={{ width: 24 }} />
+      </View>
+      <TrackList
+        tracks={singles}
+        currentTrackId={currentTrack?.id}
+        isPlaying={isPlaying}
+        onPlay={handleTrackPress}
+      />
+    </LinearGradient>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    paddingTop: 50,
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 16,
+    marginBottom: 16,
+  },
+  title: {
+    fontSize: 20,
+    fontFamily: 'Poppins-Bold',
+    color: '#fff',
+  },
+});
+

--- a/components/QueueModal.tsx
+++ b/components/QueueModal.tsx
@@ -35,21 +35,28 @@ export default function QueueModal({ visible, onClose }: Props) {
   const renderItem = ({ item, drag }: RenderItemParams<Track>) => (
     <TouchableOpacity
       onPress={() => playTrack(item, queue)}
-      className={`flex-row items-center p-2 mb-2 rounded-lg bg-white/5 ${
-        item.id === currentTrack?.id ? 'border border-violet-500' : ''
-      }`}
       onLongPress={drag}
+      style={[
+        styles.row,
+        styles.glassCard,
+        styles.brutalBorder,
+        styles.brutalShadow,
+        item.id === currentTrack?.id && styles.currentRow,
+      ]}
     >
-      <Image source={{ uri: item.coverUrl }} className="w-12 h-12 rounded-md" />
-      <View className="flex-1 ml-3">
-        <Text className="text-white text-sm font-semibold" numberOfLines={1}>
+      <Image source={{ uri: item.coverUrl }} style={styles.image} />
+      <View style={styles.meta}>
+        <Text style={styles.title} numberOfLines={1}>
           {item.title}
         </Text>
-        <Text className="text-slate-400 text-xs" numberOfLines={1}>
+        <Text style={styles.artist} numberOfLines={1}>
           {item.artist}
         </Text>
       </View>
-      <TouchableOpacity onPress={() => removeFromQueue(item.id)} className="p-2">
+      <TouchableOpacity
+        onPress={() => removeFromQueue(item.id)}
+        style={styles.removeBtn}
+      >
         <Trash2 color="#ef4444" size={18} />
       </TouchableOpacity>
     </TouchableOpacity>
@@ -110,6 +117,39 @@ const styles = StyleSheet.create({
   },
   closeBtn: {
     padding: 4,
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    padding: 12,
+    marginBottom: 8,
+    borderRadius: 12,
+    backgroundColor: 'rgba(255,255,255,0.05)',
+  },
+  currentRow: {
+    backgroundColor: 'rgba(139,92,246,0.15)',
+  },
+  image: {
+    width: 40,
+    height: 40,
+    borderRadius: 6,
+    marginRight: 12,
+  },
+  meta: { flex: 1 },
+  title: {
+    fontSize: 16,
+    fontFamily: 'Inter-SemiBold',
+    color: '#ffffff',
+  },
+  artist: {
+    fontSize: 14,
+    fontFamily: 'Inter-Regular',
+    color: '#94a3b8',
+  },
+  removeBtn: {
+    padding: 8,
+    marginLeft: 8,
+    borderRadius: 8,
   },
   glassCard: {
     backgroundColor: 'rgba(255,255,255,0.05)',


### PR DESCRIPTION
## Summary
- show artist releases and library with filterable track lists
- refresh queue modal styling to match track items

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68939c655fd08324a954babd966f566d