### PR TITLE
feat: enhance track cards and profile social pages

### DIFF
--- a/app/(detail)/artist/[id]/index.tsx
+++ b/app/(detail)/artist/[id]/index.tsx
@@ -19,9 +19,10 @@ import {
   Users,
   UserPlus,
   UserCheck,
+  Play,
+  Pause,
 } from 'lucide-react-native';
 import TrackList from '@/components/TrackList';
-import TrackItem from '@/components/TrackItem';
 
 interface Artist {
   id: string;
@@ -297,40 +298,69 @@ export default function ArtistDetailScreen() {
           <View style={styles.section}>
             <Text style={styles.sectionTitle}>Most Recent Release</Text>
             {recentRelease.type === 'track' ? (
-              <TrackItem
-                track={recentRelease.item}
-                isCurrent={currentTrack?.id === recentRelease.item.id}
-                isPlaying={isPlaying}
-                onPlay={() =>
-                  handleTrackPress(recentRelease.item, [recentRelease.item])
-                }
-                showLikeButton
-              />
-            ) : (
-              <TouchableOpacity
+              <View
                 style={[
-                  styles.albumCard,
+                  styles.featuredContainer,
                   styles.glassCard,
                   styles.brutalBorder,
                   styles.brutalShadow,
                 ]}
-                onPress={() =>
-                  router.push(`/album/${recentRelease.item.id}` as const)
-                }
               >
-                <Image
-                  source={{ uri: recentRelease.item.cover_url }}
-                  style={styles.albumCover}
-                />
-                <Text style={styles.albumTitle} numberOfLines={1}>
-                  {recentRelease.item.title}
-                </Text>
-                <Text style={styles.albumDate}>
-                  {new Date(
-                    recentRelease.item.release_date,
-                  ).toLocaleDateString()}
-                </Text>
-              </TouchableOpacity>
+                <TouchableOpacity
+                  onPress={() =>
+                    router.push(`/track/${recentRelease.item.id}` as const)
+                  }
+                >
+                  <Image
+                    source={{ uri: recentRelease.item.coverUrl }}
+                    style={styles.featuredCover}
+                  />
+                </TouchableOpacity>
+                <Text style={styles.featuredTitle}>{recentRelease.item.title}</Text>
+                <Text style={styles.featuredArtist}>{recentRelease.item.artist}</Text>
+                <TouchableOpacity
+                  style={[styles.playButton, styles.brutalBorder, styles.brutalShadow]}
+                  onPress={() =>
+                    handleTrackPress(recentRelease.item, [recentRelease.item])
+                  }
+                >
+                  {currentTrack?.id === recentRelease.item.id && isPlaying ? (
+                    <Pause color="#fff" size={24} />
+                  ) : (
+                    <Play color="#fff" size={24} />
+                  )}
+                </TouchableOpacity>
+              </View>
+            ) : (
+              <View
+                style={[
+                  styles.featuredContainer,
+                  styles.glassCard,
+                  styles.brutalBorder,
+                  styles.brutalShadow,
+                ]}
+              >
+                <TouchableOpacity
+                  onPress={() =>
+                    router.push(`/album/${recentRelease.item.id}` as const)
+                  }
+                >
+                  <Image
+                    source={{ uri: recentRelease.item.cover_url }}
+                    style={styles.featuredCover}
+                  />
+                </TouchableOpacity>
+                <Text style={styles.featuredTitle}>{recentRelease.item.title}</Text>
+                <Text style={styles.featuredArtist}>{artist?.stage_name}</Text>
+                <TouchableOpacity
+                  style={[styles.playButton, styles.brutalBorder, styles.brutalShadow]}
+                  onPress={() =>
+                    router.push(`/album/${recentRelease.item.id}` as const)
+                  }
+                >
+                  <Play color="#fff" size={24} />
+                </TouchableOpacity>
+              </View>
             )}
           </View>
         )}
@@ -504,6 +534,37 @@ const styles = StyleSheet.create({
     fontSize: 14,
     fontFamily: 'Inter-SemiBold',
     color: '#8b5cf6',
+  },
+  featuredContainer: {
+    alignItems: 'center',
+    padding: 16,
+    marginTop: 16,
+    borderRadius: 12,
+  },
+  featuredCover: {
+    width: 220,
+    height: 220,
+    borderRadius: 12,
+    marginBottom: 16,
+  },
+  featuredTitle: {
+    fontSize: 18,
+    fontFamily: 'Poppins-Bold',
+    color: '#fff',
+    textAlign: 'center',
+    marginBottom: 4,
+  },
+  featuredArtist: {
+    fontSize: 14,
+    fontFamily: 'Inter-Regular',
+    color: '#94a3b8',
+    textAlign: 'center',
+  },
+  playButton: {
+    marginTop: 12,
+    padding: 12,
+    borderRadius: 24,
+    backgroundColor: 'rgba(255,255,255,0.05)',
   },
   albumList: {
     paddingHorizontal: 16,

--- a/app/(tabs)/profile/followers.tsx
+++ b/app/(tabs)/profile/followers.tsx
@@ -1,0 +1,125 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, StyleSheet, FlatList, TouchableOpacity, Image } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+import { useAuth } from '@/providers/AuthProvider';
+import { supabase } from '@/services/supabase';
+import { apiService } from '@/services/api';
+import { router } from 'expo-router';
+import { ArrowLeft } from 'lucide-react-native';
+
+interface UserItem {
+  id: string;
+  username: string;
+  avatar_url: string | null;
+}
+
+type Row = { follower: UserItem };
+
+export default function FollowersScreen() {
+  const { user } = useAuth();
+  const [followers, setFollowers] = useState<UserItem[]>([]);
+
+  useEffect(() => {
+    const load = async () => {
+      if (!user) return;
+      const { data } = await supabase
+        .from('user_follows')
+        .select('follower:profiles!user_follows_follower_id_fkey(id, username, avatar_url)')
+        .eq('following_id', user.id);
+      setFollowers(((data as Row[]) || []).map((d) => d.follower));
+    };
+    load();
+  }, [user]);
+
+  return (
+    <LinearGradient colors={['#0f172a', '#1e293b', '#0f172a']} style={styles.container}>
+      <View style={styles.header}>
+        <TouchableOpacity onPress={() => router.back()} style={styles.backButton}>
+          <ArrowLeft color="#fff" size={24} />
+        </TouchableOpacity>
+        <Text style={styles.headerTitle}>Followers</Text>
+      </View>
+      <FlatList
+        data={followers}
+        keyExtractor={(item) => item.id}
+        contentContainerStyle={styles.list}
+        renderItem={({ item }) => (
+          <TouchableOpacity
+            style={[styles.userItem, styles.glassCard, styles.brutalBorder, styles.brutalShadow]}
+            onPress={() => router.push(`/user/${item.id}` as const)}
+          >
+            {item.avatar_url ? (
+              <Image
+                source={{ uri: apiService.getPublicUrl('images', item.avatar_url) }}
+                style={styles.avatar}
+              />
+            ) : (
+              <View style={styles.avatar} />
+            )}
+            <Text style={styles.username}>{item.username}</Text>
+          </TouchableOpacity>
+        )}
+      />
+    </LinearGradient>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingTop: 50,
+    paddingHorizontal: 16,
+    paddingBottom: 16,
+    justifyContent: 'center',
+  },
+  backButton: {
+    position: 'absolute',
+    left: 16,
+    top: 50,
+    padding: 8,
+  },
+  headerTitle: {
+    fontSize: 20,
+    fontFamily: 'Poppins-Bold',
+    color: '#fff',
+  },
+  list: {
+    padding: 16,
+    gap: 12,
+  },
+  userItem: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    padding: 12,
+    borderRadius: 12,
+    gap: 12,
+    marginBottom: 12,
+  },
+  avatar: {
+    width: 50,
+    height: 50,
+    borderRadius: 25,
+    backgroundColor: '#1e293b',
+  },
+  username: {
+    fontSize: 16,
+    fontFamily: 'Inter-SemiBold',
+    color: '#fff',
+  },
+  glassCard: {
+    backgroundColor: 'rgba(255,255,255,0.05)',
+  },
+  brutalBorder: {
+    borderWidth: 2,
+    borderColor: 'rgba(255,255,255,0.2)',
+  },
+  brutalShadow: {
+    shadowColor: '#000',
+    shadowOffset: { width: 4, height: 4 },
+    shadowOpacity: 0.4,
+    shadowRadius: 6,
+    elevation: 8,
+  },
+});

--- a/app/(tabs)/profile/following.tsx
+++ b/app/(tabs)/profile/following.tsx
@@ -1,0 +1,125 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, StyleSheet, FlatList, TouchableOpacity, Image } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+import { useAuth } from '@/providers/AuthProvider';
+import { supabase } from '@/services/supabase';
+import { apiService } from '@/services/api';
+import { router } from 'expo-router';
+import { ArrowLeft } from 'lucide-react-native';
+
+interface UserItem {
+  id: string;
+  username: string;
+  avatar_url: string | null;
+}
+
+type Row = { following: UserItem };
+
+export default function FollowingScreen() {
+  const { user } = useAuth();
+  const [following, setFollowing] = useState<UserItem[]>([]);
+
+  useEffect(() => {
+    const load = async () => {
+      if (!user) return;
+      const { data } = await supabase
+        .from('user_follows')
+        .select('following:profiles!user_follows_following_id_fkey(id, username, avatar_url)')
+        .eq('follower_id', user.id);
+      setFollowing(((data as Row[]) || []).map((d) => d.following));
+    };
+    load();
+  }, [user]);
+
+  return (
+    <LinearGradient colors={['#0f172a', '#1e293b', '#0f172a']} style={styles.container}>
+      <View style={styles.header}>
+        <TouchableOpacity onPress={() => router.back()} style={styles.backButton}>
+          <ArrowLeft color="#fff" size={24} />
+        </TouchableOpacity>
+        <Text style={styles.headerTitle}>Following</Text>
+      </View>
+      <FlatList
+        data={following}
+        keyExtractor={(item) => item.id}
+        contentContainerStyle={styles.list}
+        renderItem={({ item }) => (
+          <TouchableOpacity
+            style={[styles.userItem, styles.glassCard, styles.brutalBorder, styles.brutalShadow]}
+            onPress={() => router.push(`/user/${item.id}` as const)}
+          >
+            {item.avatar_url ? (
+              <Image
+                source={{ uri: apiService.getPublicUrl('images', item.avatar_url) }}
+                style={styles.avatar}
+              />
+            ) : (
+              <View style={styles.avatar} />
+            )}
+            <Text style={styles.username}>{item.username}</Text>
+          </TouchableOpacity>
+        )}
+      />
+    </LinearGradient>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingTop: 50,
+    paddingHorizontal: 16,
+    paddingBottom: 16,
+    justifyContent: 'center',
+  },
+  backButton: {
+    position: 'absolute',
+    left: 16,
+    top: 50,
+    padding: 8,
+  },
+  headerTitle: {
+    fontSize: 20,
+    fontFamily: 'Poppins-Bold',
+    color: '#fff',
+  },
+  list: {
+    padding: 16,
+    gap: 12,
+  },
+  userItem: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    padding: 12,
+    borderRadius: 12,
+    gap: 12,
+    marginBottom: 12,
+  },
+  avatar: {
+    width: 50,
+    height: 50,
+    borderRadius: 25,
+    backgroundColor: '#1e293b',
+  },
+  username: {
+    fontSize: 16,
+    fontFamily: 'Inter-SemiBold',
+    color: '#fff',
+  },
+  glassCard: {
+    backgroundColor: 'rgba(255,255,255,0.05)',
+  },
+  brutalBorder: {
+    borderWidth: 2,
+    borderColor: 'rgba(255,255,255,0.2)',
+  },
+  brutalShadow: {
+    shadowColor: '#000',
+    shadowOffset: { width: 4, height: 4 },
+    shadowOpacity: 0.4,
+    shadowRadius: 6,
+    elevation: 8,
+  },
+});

--- a/app/(tabs)/profile/requests.tsx
+++ b/app/(tabs)/profile/requests.tsx
@@ -1,0 +1,219 @@
+import React, { useEffect, useState } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  FlatList,
+  TouchableOpacity,
+  Image,
+} from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+import { useAuth } from '@/providers/AuthProvider';
+import { supabase } from '@/services/supabase';
+import { apiService } from '@/services/api';
+import { router } from 'expo-router';
+import { ArrowLeft, Check, X } from 'lucide-react-native';
+
+interface UserItem {
+  id: string;
+  username: string;
+  avatar_url: string | null;
+}
+interface RequestItem {
+  id: string;
+  user: UserItem;
+}
+
+type IncomingRow = { id: string; requester: UserItem };
+type OutgoingRow = { id: string; requested: UserItem };
+
+export default function FollowRequestsScreen() {
+  const { user } = useAuth();
+  const [incoming, setIncoming] = useState<RequestItem[]>([]);
+  const [outgoing, setOutgoing] = useState<RequestItem[]>([]);
+
+  useEffect(() => {
+    if (!user) return;
+    const load = async () => {
+      const { data: incomingData } = await supabase
+        .from('follower_requests')
+        .select('id, requester:profiles!follower_requests_requester_id_fkey(id, username, avatar_url)')
+        .eq('requested_id', user.id);
+      setIncoming(
+        ((incomingData as IncomingRow[]) || []).map((r) => ({ id: r.id, user: r.requester }))
+      );
+
+      const { data: outgoingData } = await supabase
+        .from('follower_requests')
+        .select('id, requested:profiles!follower_requests_requested_id_fkey(id, username, avatar_url)')
+        .eq('requester_id', user.id);
+      setOutgoing(
+        ((outgoingData as OutgoingRow[]) || []).map((r) => ({ id: r.id, user: r.requested }))
+      );
+    };
+    load();
+  }, [user]);
+
+  const respond = async (id: string, accept: boolean) => {
+    await supabase.rpc('respond_to_follow_request', { request_id: id, accept });
+    setIncoming((prev) => prev.filter((r) => r.id !== id));
+  };
+
+  const renderItem = ({ item }: { item: RequestItem }) => (
+    <View style={[styles.requestItem, styles.glassCard, styles.brutalBorder, styles.brutalShadow]}>
+      {item.user.avatar_url ? (
+        <Image
+          source={{ uri: apiService.getPublicUrl('images', item.user.avatar_url) }}
+          style={styles.avatar}
+        />
+      ) : (
+        <View style={styles.avatar} />
+      )}
+      <Text style={styles.username}>{item.user.username}</Text>
+      <View style={styles.requestActions}>
+        <TouchableOpacity
+          style={[styles.actionButton, styles.accept]}
+          onPress={() => respond(item.id, true)}
+        >
+          <Check color="#fff" size={16} />
+        </TouchableOpacity>
+        <TouchableOpacity
+          style={[styles.actionButton, styles.deny]}
+          onPress={() => respond(item.id, false)}
+        >
+          <X color="#fff" size={16} />
+        </TouchableOpacity>
+      </View>
+    </View>
+  );
+
+  const renderPending = ({ item }: { item: RequestItem }) => (
+    <View style={[styles.requestItem, styles.glassCard, styles.brutalBorder, styles.brutalShadow]}>
+      {item.user.avatar_url ? (
+        <Image
+          source={{ uri: apiService.getPublicUrl('images', item.user.avatar_url) }}
+          style={styles.avatar}
+        />
+      ) : (
+        <View style={styles.avatar} />
+      )}
+      <Text style={styles.username}>{item.user.username}</Text>
+      <Text style={styles.pendingText}>Requested</Text>
+    </View>
+  );
+
+  return (
+    <LinearGradient colors={['#0f172a', '#1e293b', '#0f172a']} style={styles.container}>
+      <View style={styles.header}>
+        <TouchableOpacity onPress={() => router.back()} style={styles.backButton}>
+          <ArrowLeft color="#fff" size={24} />
+        </TouchableOpacity>
+        <Text style={styles.headerTitle}>Follow Requests</Text>
+      </View>
+      <FlatList
+        ListHeaderComponent={() => <Text style={styles.sectionTitle}>Incoming</Text>}
+        data={incoming}
+        keyExtractor={(item) => item.id}
+        renderItem={renderItem}
+        contentContainerStyle={styles.list}
+        ListFooterComponent={() => (
+          <>
+            <Text style={[styles.sectionTitle, styles.pendingHeader]}>Pending</Text>
+            {outgoing.map((item) => (
+              <View key={item.id}>{renderPending({ item })}</View>
+            ))}
+          </>
+        )}
+      />
+    </LinearGradient>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingTop: 50,
+    paddingHorizontal: 16,
+    paddingBottom: 16,
+    justifyContent: 'center',
+  },
+  backButton: {
+    position: 'absolute',
+    left: 16,
+    top: 50,
+    padding: 8,
+  },
+  headerTitle: {
+    fontSize: 20,
+    fontFamily: 'Poppins-Bold',
+    color: '#fff',
+  },
+  list: {
+    padding: 16,
+    gap: 12,
+  },
+  sectionTitle: {
+    fontSize: 18,
+    fontFamily: 'Poppins-Bold',
+    color: '#fff',
+    marginBottom: 12,
+  },
+  pendingHeader: {
+    marginTop: 24,
+  },
+  requestItem: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    padding: 12,
+    borderRadius: 12,
+    gap: 12,
+    marginBottom: 12,
+  },
+  avatar: {
+    width: 50,
+    height: 50,
+    borderRadius: 25,
+    backgroundColor: '#1e293b',
+  },
+  username: {
+    flex: 1,
+    fontSize: 16,
+    fontFamily: 'Inter-SemiBold',
+    color: '#fff',
+  },
+  requestActions: {
+    flexDirection: 'row',
+    gap: 8,
+  },
+  actionButton: {
+    padding: 8,
+    borderRadius: 8,
+  },
+  accept: {
+    backgroundColor: '#16a34a',
+  },
+  deny: {
+    backgroundColor: '#dc2626',
+  },
+  pendingText: {
+    fontSize: 14,
+    fontFamily: 'Inter-Regular',
+    color: '#94a3b8',
+  },
+  glassCard: {
+    backgroundColor: 'rgba(255,255,255,0.05)',
+  },
+  brutalBorder: {
+    borderWidth: 2,
+    borderColor: 'rgba(255,255,255,0.2)',
+  },
+  brutalShadow: {
+    shadowColor: '#000',
+    shadowOffset: { width: 4, height: 4 },
+    shadowOpacity: 0.4,
+    shadowRadius: 6,
+    elevation: 8,
+  },
+});

--- a/app/(tabs)/profile/settings.tsx
+++ b/app/(tabs)/profile/settings.tsx
@@ -1,0 +1,138 @@
+import React, { useState } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  TouchableOpacity,
+  ScrollView,
+  Switch,
+} from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+import { router } from 'expo-router';
+import { useAuth } from '@/providers/AuthProvider';
+import { supabase } from '@/services/supabase';
+import { ArrowLeft } from 'lucide-react-native';
+
+export default function ProfileSettings() {
+  const { user, logout } = useAuth();
+  const [isPrivate, setIsPrivate] = useState(user?.is_private ?? false);
+
+  const togglePrivacy = async () => {
+    if (!user) return;
+    const newValue = !isPrivate;
+    setIsPrivate(newValue);
+    await supabase.from('profiles').update({ is_private: newValue }).eq('id', user.id);
+  };
+
+  return (
+    <LinearGradient colors={['#0f172a', '#1e293b', '#0f172a']} style={styles.container}>
+      <View style={styles.header}>
+        <TouchableOpacity onPress={() => router.back()} style={styles.backButton}>
+          <ArrowLeft color="#fff" size={24} />
+        </TouchableOpacity>
+        <Text style={styles.headerTitle}>Settings & Account</Text>
+      </View>
+      <ScrollView contentContainerStyle={styles.content}>
+        <TouchableOpacity
+          style={[styles.item, styles.glassCard, styles.brutalBorder, styles.brutalShadow]}
+          onPress={() => router.push('/profile?edit=true' as const)}
+        >
+          <Text style={styles.itemText}>Edit Profile</Text>
+        </TouchableOpacity>
+        <View
+          style={[styles.item, styles.row, styles.glassCard, styles.brutalBorder, styles.brutalShadow]}
+        >
+          <Text style={styles.itemText}>Private Account</Text>
+          <Switch value={isPrivate} onValueChange={togglePrivacy} />
+        </View>
+        <TouchableOpacity
+          style={[styles.item, styles.glassCard, styles.brutalBorder, styles.brutalShadow]}
+          onPress={() => router.push('/profile/requests' as const)}
+        >
+          <Text style={styles.itemText}>Manage Follow Requests</Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          style={[styles.item, styles.glassCard, styles.brutalBorder, styles.brutalShadow]}
+        >
+          <Text style={styles.itemText}>Notifications</Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          style={[styles.item, styles.glassCard, styles.brutalBorder, styles.brutalShadow]}
+        >
+          <Text style={styles.itemText}>Preferences</Text>
+        </TouchableOpacity>
+        <TouchableOpacity style={styles.logoutButton} onPress={logout}>
+          <Text style={styles.logoutText}>Log Out</Text>
+        </TouchableOpacity>
+      </ScrollView>
+    </LinearGradient>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingTop: 50,
+    paddingHorizontal: 16,
+    paddingBottom: 16,
+    justifyContent: 'center',
+  },
+  backButton: {
+    position: 'absolute',
+    left: 16,
+    top: 50,
+    padding: 8,
+  },
+  headerTitle: {
+    fontSize: 20,
+    fontFamily: 'Poppins-Bold',
+    color: '#fff',
+  },
+  content: {
+    padding: 16,
+    paddingBottom: 40,
+    gap: 16,
+  },
+  item: {
+    padding: 16,
+    borderRadius: 12,
+  },
+  row: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  itemText: {
+    fontSize: 16,
+    fontFamily: 'Inter-SemiBold',
+    color: '#fff',
+  },
+  logoutButton: {
+    marginTop: 32,
+    padding: 16,
+    borderRadius: 12,
+    backgroundColor: '#ef4444',
+    alignItems: 'center',
+  },
+  logoutText: {
+    color: '#fff',
+    fontFamily: 'Inter-SemiBold',
+    fontSize: 16,
+  },
+  glassCard: {
+    backgroundColor: 'rgba(255,255,255,0.05)',
+  },
+  brutalBorder: {
+    borderWidth: 2,
+    borderColor: 'rgba(255,255,255,0.2)',
+  },
+  brutalShadow: {
+    shadowColor: '#000',
+    shadowOffset: { width: 4, height: 4 },
+    shadowOpacity: 0.4,
+    shadowRadius: 6,
+    elevation: 8,
+  },
+});

--- a/components/MiniTrackCard.tsx
+++ b/components/MiniTrackCard.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { View, Text, Image, StyleSheet, TouchableOpacity } from 'react-native';
-import { Play, Pause, Heart } from 'lucide-react-native';
-import { Track, useMusic } from '@/providers/MusicProvider';
+import { Play, Pause } from 'lucide-react-native';
+import { Track } from '@/providers/MusicProvider';
+import TrackOptionsMenu from './TrackOptionsMenu';
 import { router } from 'expo-router';
 
 interface Props {
@@ -9,7 +10,6 @@ interface Props {
   isCurrent?: boolean;
   isPlaying?: boolean;
   onPlay: () => void;
-  showLikeButton?: boolean;
 }
 
 export default function MiniTrackCard({
@@ -17,10 +17,7 @@ export default function MiniTrackCard({
   isCurrent,
   isPlaying,
   onPlay,
-  showLikeButton,
 }: Props) {
-  const { toggleLike, likedSongIds } = useMusic();
-  const isLiked = track.isLiked || likedSongIds.includes(track.id);
 
   const subtitle =
     track.artist +
@@ -48,18 +45,6 @@ export default function MiniTrackCard({
         {subtitle}
       </Text>
       <View style={styles.actions}>
-        {showLikeButton && (
-          <TouchableOpacity
-            style={[styles.iconButton, styles.brutalBorder]}
-            onPress={() => toggleLike(track.id)}
-          >
-            <Heart
-              size={16}
-              color={isLiked ? '#ef4444' : '#8b5cf6'}
-              fill={isLiked ? '#ef4444' : 'transparent'}
-            />
-          </TouchableOpacity>
-        )}
         <TouchableOpacity
           style={[styles.iconButton, styles.brutalBorder]}
           onPress={onPlay}
@@ -70,6 +55,7 @@ export default function MiniTrackCard({
             <Play color="#8b5cf6" size={16} />
           )}
         </TouchableOpacity>
+        <TrackOptionsMenu track={track} />
       </View>
     </View>
   );


### PR DESCRIPTION
## Summary
- Add play and options controls to MiniTrackCard for quick playback and queueing
- Spotlight most recent artist release with enlarged art and play access
- Build profile social screens with settings, privacy toggle and follow requests

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68939f7f1d048324ab27546f117c39cb